### PR TITLE
Fix MarkdownV2 escaping, video thumbnails, and docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,15 @@ services:
     container_name: tgmr
     image: realies/tgmr:latest
     restart: unless-stopped
+    env_file: .env
     environment:
-      - BOT_TOKEN=your_telegram_bot_token_here
-      - MAX_FILE_SIZE=50000000
-      - DOWNLOAD_TIMEOUT=300
-      - RATE_LIMIT=10
-      - COOLDOWN=60
-      - TMP_DIR=/tmp/tgmr
-      - SUPPORTED_DOMAINS=bandcamp.com,facebook.com,youtube.com,youtu.be,vimeo.com,soundcloud.com,mixcloud.com,instagram.com,twitter.com,x.com
-      # Cookie configuration (optional)
-      # - COOKIES_FILE=/cookies/default.txt  # Default fallback for all sites
-      # - COOKIES_FILE_YOUTUBE=/cookies/youtube.txt
-      # - COOKIES_FILE_INSTAGRAM=/cookies/instagram.txt
-      # - COOKIES_FILE_TWITTER=/cookies/twitter.txt  # Will be used for both twitter.com and x.com
-    # volumes:
-      # Mount cookies directory with write support (yt-dlp updates cookies)
-      # - ./cookies:/cookies
+      - MAX_FILE_SIZE=${MAX_FILE_SIZE:-50000000}
+      - DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT:-300}
+      - RATE_LIMIT=${RATE_LIMIT:-10}
+      - COOLDOWN=${COOLDOWN:-60}
+      - TMP_DIR=${TMP_DIR:-/tmp/tgmr}
+      - SUPPORTED_DOMAINS=${SUPPORTED_DOMAINS:-bandcamp.com,facebook.com,youtube.com,youtu.be,vimeo.com,soundcloud.com,mixcloud.com,instagram.com,twitter.com,x.com}
+    volumes:
+      - ./cookies:/cookies
     tmpfs:
       - /tmp/tgmr:exec,size=1G

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
+      - BOT_TOKEN=${BOT_TOKEN:?Set BOT_TOKEN in .env}
       - MAX_FILE_SIZE=${MAX_FILE_SIZE:-50000000}
       - DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT:-300}
       - RATE_LIMIT=${RATE_LIMIT:-10}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,12 +30,7 @@ export default [
       'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 0, maxBOF: 0 }],
       'eol-last': ['error', 'always'],
       'no-whitespace-before-property': 'error',
-      'prettier/prettier': ['error', {
-        singleQuote: true,
-        trailingComma: 'es5',
-        printWidth: 100,
-        semi: true
-      }]
+      'prettier/prettier': 'error'
     }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=20.19.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
   },
   "dependencies": {
     "grammy": "^1.41.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "grammy": "^1.41.1"

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -19,16 +19,16 @@ export async function createBot(): Promise<Bot> {
   // Set up command handlers
   bot.command('start', (ctx) =>
     ctx.reply(
-      "Hello! I can help you download media from various platforms. Just send me a link, and I'll reply with the media."
-    )
+      "Hello! I can help you download media from various platforms. Just send me a link, and I'll reply with the media.",
+    ),
   );
 
   bot.command('help', (ctx) =>
     ctx.reply(
       `Send me a link from ${getSupportedPlatforms()}, and I'll download and send you the media.\n\n` +
         "For audio-only content, I'll send it as a voice message. For videos, I'll send them as video files. " +
-        "For images, I'll send them in the highest quality available."
-    )
+        "For images, I'll send them in the highest quality available.",
+    ),
   );
 
   // Handle all messages

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -50,7 +50,7 @@ class ChatActionManager {
 
   constructor(
     private ctx: Context,
-    private chatId: number
+    private chatId: number,
   ) {}
 
   async start(action: ChatAction): Promise<void> {
@@ -214,7 +214,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
           maxAttempts: 3,
           initialDelay: 3000,
           maxDelay: 20000,
-        }
+        },
       );
 
       // Stop the action before processing result
@@ -236,10 +236,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
       const mediaInfos = await Promise.all(
         result.filePaths.map(async (path) => {
           const { stdout: ffprobeOutput } = await execAsync(
-            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`
+            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`,
           );
           return JSON.parse(ffprobeOutput) as FFprobeData;
-        })
+        }),
       );
 
       // Format stream info for each file
@@ -256,7 +256,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
 
               // Extract first frame as thumbnail, scaled to Telegram's 320px limit
               await execAsync(
-                `ffmpeg -y -i "${path}" -vf "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease" -q:v 6 -frames:v 1 "${thumbnailPath}"`
+                `ffmpeg -y -i "${path}" -vf "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease" -q:v 6 -frames:v 1 "${thumbnailPath}"`,
               );
 
               // Verify file meets Telegram's thumbnail requirements (non-empty, <=200KB)
@@ -318,10 +318,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
           if (fileSize > env.MAX_FILE_SIZE) {
             logger.warn(
               `File size ${fileSizeMB}MB exceeds limit of ${env.MAX_FILE_SIZE / 1024 / 1024}MB`,
-              { ...logContext, requestId }
+              { ...logContext, requestId },
             );
             throw new Error(
-              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`
+              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`,
             );
           }
 
@@ -334,13 +334,13 @@ export async function handleMessage(ctx: Context): Promise<void> {
             streamInfo,
             fileSizeMB,
           };
-        })
+        }),
       );
 
       // Escape special characters for MarkdownV2
       const escapedTitle = normalizeLineBreaks(result.mediaInfo.title).replace(
         /[_*[\]()~`>#+\-=|{}.!\\]/g,
-        '\\$&'
+        '\\$&',
       );
       const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
@@ -389,7 +389,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
             const videoSummary = Array.from(videoFormats.entries())
               .map(
                 ([_, info]) =>
-                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`
+                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
               )
               .join(', ');
             formatSummary.push(videoSummary);
@@ -451,7 +451,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
         const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
         caption = [`[${escapedTitle}](${escapedUrl})`, `\`${escapedInfo}, ${escapedSize}MB\``].join(
-          '\n'
+          '\n',
         );
 
         const item = mediaItems[0];
@@ -494,11 +494,11 @@ export async function handleMessage(ctx: Context): Promise<void> {
               downloader
                 .cleanup(file)
                 .catch((error) =>
-                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error })
-                )
-            )
+                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
+                ),
+            ),
           );
-        })
+        }),
       );
       logger.debug(`Successfully processed media request for ${userInfo}`, {
         ...logContext,

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -50,7 +50,7 @@ class ChatActionManager {
 
   constructor(
     private ctx: Context,
-    private chatId: number
+    private chatId: number,
   ) {}
 
   async start(action: ChatAction): Promise<void> {
@@ -214,7 +214,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
           maxAttempts: 3,
           initialDelay: 3000,
           maxDelay: 20000,
-        }
+        },
       );
 
       // Stop the action before processing result
@@ -236,10 +236,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
       const mediaInfos = await Promise.all(
         result.filePaths.map(async (path) => {
           const { stdout: ffprobeOutput } = await execAsync(
-            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`
+            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`,
           );
           return JSON.parse(ffprobeOutput) as FFprobeData;
-        })
+        }),
       );
 
       // Format stream info for each file
@@ -314,10 +314,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
           if (fileSize > env.MAX_FILE_SIZE) {
             logger.warn(
               `File size ${fileSizeMB}MB exceeds limit of ${env.MAX_FILE_SIZE / 1024 / 1024}MB`,
-              { ...logContext, requestId }
+              { ...logContext, requestId },
             );
             throw new Error(
-              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`
+              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`,
             );
           }
 
@@ -330,15 +330,15 @@ export async function handleMessage(ctx: Context): Promise<void> {
             streamInfo,
             fileSizeMB,
           };
-        })
+        }),
       );
 
       // Escape special characters for MarkdownV2
       const escapedTitle = normalizeLineBreaks(result.mediaInfo.title).replace(
-        /[_*[\]()~`>#+\-=|{}.!]/g,
-        '\\$&'
+        /[_*[\]()~`>#+\-=|{}.!\\]/g,
+        '\\$&',
       );
-      const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&');
+      const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
       // Create a summary for multiple files
       let caption: string;
@@ -385,7 +385,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
             const videoSummary = Array.from(videoFormats.entries())
               .map(
                 ([_, info]) =>
-                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`
+                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
               )
               .join(', ');
             formatSummary.push(videoSummary);
@@ -393,8 +393,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
 
           const escapedSummary = formatSummary
             .join(', ')
-            .replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&');
-          const escapedSize = chunkTotalSize.toFixed(1).replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&');
+            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
+          const escapedSize = chunkTotalSize
+            .toFixed(1)
+            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
           // Create chunk-specific caption
           const chunkCaption =
@@ -415,7 +417,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
                       parse_mode: 'MarkdownV2' as const,
                     }
                   : {}),
-                ...(item.thumbnail && { thumb: item.thumbnail }),
+                ...(item.thumbnail && { thumbnail: item.thumbnail }),
                 ...(item.videoWidth &&
                   item.videoHeight && {
                     width: item.videoWidth,
@@ -441,11 +443,11 @@ export async function handleMessage(ctx: Context): Promise<void> {
         }
       } else {
         // Single file - use detailed info
-        const escapedInfo = mediaItems[0].streamInfo.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&');
-        const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&');
+        const escapedInfo = mediaItems[0].streamInfo.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
+        const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
         caption = [`[${escapedTitle}](${escapedUrl})`, `\`${escapedInfo}, ${escapedSize}MB\``].join(
-          '\n'
+          '\n',
         );
 
         const item = mediaItems[0];
@@ -460,7 +462,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
             caption,
             reply_to_message_id: messageId,
             parse_mode: 'MarkdownV2',
-            ...(item.thumbnail && { thumb: item.thumbnail }),
+            ...(item.thumbnail && { thumbnail: item.thumbnail }),
             ...(item.videoWidth &&
               item.videoHeight && {
                 width: item.videoWidth,
@@ -488,11 +490,11 @@ export async function handleMessage(ctx: Context): Promise<void> {
               downloader
                 .cleanup(file)
                 .catch((error) =>
-                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error })
-                )
-            )
+                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
+                ),
+            ),
           );
-        })
+        }),
       );
       logger.debug(`Successfully processed media request for ${userInfo}`, {
         ...logContext,

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -50,7 +50,7 @@ class ChatActionManager {
 
   constructor(
     private ctx: Context,
-    private chatId: number,
+    private chatId: number
   ) {}
 
   async start(action: ChatAction): Promise<void> {
@@ -214,7 +214,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
           maxAttempts: 3,
           initialDelay: 3000,
           maxDelay: 20000,
-        },
+        }
       );
 
       // Stop the action before processing result
@@ -236,10 +236,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
       const mediaInfos = await Promise.all(
         result.filePaths.map(async (path) => {
           const { stdout: ffprobeOutput } = await execAsync(
-            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`,
+            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`
           );
           return JSON.parse(ffprobeOutput) as FFprobeData;
-        }),
+        })
       );
 
       // Format stream info for each file
@@ -254,12 +254,16 @@ export async function handleMessage(ctx: Context): Promise<void> {
               logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
               const thumbnailPath = `${path}.thumb.jpg`;
 
-              // Extract first frame as thumbnail
-              await execAsync(`ffmpeg -y -i "${path}" -vframes 1 "${thumbnailPath}"`);
+              // Extract first frame as thumbnail, scaled to Telegram's 320px limit
+              await execAsync(
+                `ffmpeg -y -i "${path}" -vf "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease" -q:v 6 -frames:v 1 "${thumbnailPath}"`
+              );
 
-              // Verify file exists and has size
+              // Verify file meets Telegram's thumbnail requirements (non-empty, <=200KB)
               const stats = await statAsync(thumbnailPath);
-              if (stats.size === 0) throw new Error('Thumbnail is empty');
+              if (stats.size === 0 || stats.size > 200 * 1024) {
+                throw new Error('Thumbnail must be non-empty and <= 200KB');
+              }
 
               logger.debug('Thumbnail created successfully', {
                 ...logContext,
@@ -314,10 +318,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
           if (fileSize > env.MAX_FILE_SIZE) {
             logger.warn(
               `File size ${fileSizeMB}MB exceeds limit of ${env.MAX_FILE_SIZE / 1024 / 1024}MB`,
-              { ...logContext, requestId },
+              { ...logContext, requestId }
             );
             throw new Error(
-              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`,
+              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`
             );
           }
 
@@ -330,13 +334,13 @@ export async function handleMessage(ctx: Context): Promise<void> {
             streamInfo,
             fileSizeMB,
           };
-        }),
+        })
       );
 
       // Escape special characters for MarkdownV2
       const escapedTitle = normalizeLineBreaks(result.mediaInfo.title).replace(
         /[_*[\]()~`>#+\-=|{}.!\\]/g,
-        '\\$&',
+        '\\$&'
       );
       const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
@@ -385,7 +389,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
             const videoSummary = Array.from(videoFormats.entries())
               .map(
                 ([_, info]) =>
-                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
+                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`
               )
               .join(', ');
             formatSummary.push(videoSummary);
@@ -447,7 +451,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
         const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
 
         caption = [`[${escapedTitle}](${escapedUrl})`, `\`${escapedInfo}, ${escapedSize}MB\``].join(
-          '\n',
+          '\n'
         );
 
         const item = mediaItems[0];
@@ -490,11 +494,11 @@ export async function handleMessage(ctx: Context): Promise<void> {
               downloader
                 .cleanup(file)
                 .catch((error) =>
-                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-                ),
-            ),
+                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error })
+                )
+            )
           );
-        }),
+        })
       );
       logger.debug(`Successfully processed media request for ${userInfo}`, {
         ...logContext,

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -14,7 +14,7 @@ export class Cleanup {
       // Only remove contents of the directory, not the directory itself
       const files = await readdir(env.TMP_DIR);
       await Promise.all(
-        files.map((file) => rm(join(env.TMP_DIR, file), { recursive: true, force: true }))
+        files.map((file) => rm(join(env.TMP_DIR, file), { recursive: true, force: true })),
       );
       logger.info(`Initialized temp directory: ${env.TMP_DIR}`);
     } catch (error) {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -25,7 +25,7 @@ const defaultOptions: Required<RetryOptions> = {
 
 export async function withRetry<T>(
   operation: () => Promise<T>,
-  options: RetryOptions = {}
+  options: RetryOptions = {},
 ): Promise<T> {
   const opts = { ...defaultOptions, ...options };
   let lastError: Error | undefined;
@@ -38,7 +38,7 @@ export async function withRetry<T>(
       lastError = error as Error;
       const errorMessage = lastError.message || String(error);
       const isRetryable = opts.retryableErrors.some((pattern) =>
-        typeof pattern === 'string' ? errorMessage.includes(pattern) : pattern.test(errorMessage)
+        typeof pattern === 'string' ? errorMessage.includes(pattern) : pattern.test(errorMessage),
       );
 
       if (!isRetryable || attempt === opts.maxAttempts) {
@@ -48,7 +48,7 @@ export async function withRetry<T>(
       logger.warn(
         `Operation failed (attempt ${attempt}/${opts.maxAttempts}), retrying in ${
           delay / 1000
-        }s: ${errorMessage}`
+        }s: ${errorMessage}`,
       );
 
       await new Promise((resolve) => setTimeout(resolve, delay));


### PR DESCRIPTION
## Summary

- **Fix 6 CodeQL alerts** (`js/incomplete-sanitization`): Add backslash (`\`) to the MarkdownV2 escape regex character class — titles or URLs containing a literal backslash would pass through unescaped and break Telegram's MarkdownV2 parser
- **Fix video thumbnails not being sent**: Rename `thumb` to `thumbnail` in both `replyWithVideo` and media group video options — the property was renamed in Telegram Bot API 6.6 (March 2023), so `thumb` was silently ignored and thumbnails were never attached to video messages
- **Refactor docker-compose.yml for .env usage**: Replace hardcoded environment values with `env_file: .env` + `${VAR:-default}` interpolation, so the compose file can be used as-is from the repo without local edits — users only need to create a `.env` file with `BOT_TOKEN` and any optional overrides (cookie files, etc.)
- **Bump Node.js engines** to `>=20.19.0` to match ESLint 10's requirement (merged in #253)

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `yarn lint` passes
- [ ] Verify `docker compose config` resolves correctly with a `.env` file containing `BOT_TOKEN=test`
- [ ] Send a link with a backslash in the title to verify MarkdownV2 doesn't break
- [ ] Send a video link and verify thumbnail is attached to the reply
- [ ] Verify bot starts and processes a media URL end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js engine support to newer ranges.
  * Configuration now loads from a .env file with safer defaults for file handling, timeouts, rate limits, and enabled cookie support.

* **Bug Fixes**
  * Improved video thumbnail generation, scaling and stricter size validation for reliable previews.
  * Fixed Markdown escaping to improve message formatting.

* **Style**
  * Minor formatting and lint rule simplifications across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->