### PR TITLE
Comprehensive security, performance, reliability, and feature overhaul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+tmp
+.git
+.env
+*.md
+*.log
+.DS_Store
+.vscode
+.idea
+cookies

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Required
+BOT_TOKEN=your_telegram_bot_token_here
+
+# Optional cookie files (for authenticated downloads)
+# COOKIES_FILE_YOUTUBE=/cookies/youtube.txt
+# COOKIES_FILE_INSTAGRAM=/cookies/instagram.txt
+# COOKIES_FILE_TWITTER=/cookies/twitter.txt

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Required
+BOT_TOKEN=your_telegram_bot_token_here
+
+# Optional cookie files (for authenticated downloads)
+# COOKIES_FILE_YOUTUBE=/cookies/youtube.txt
+# COOKIES_FILE_INSTAGRAM=/cookies/instagram.txt
+# COOKIES_FILE_TWITTER=/cookies/twitter.txt
+
+# Optional per-site browser fingerprint headers (keep cookies fresh longer).
+# Pattern: <SITE>_<HEADER_NAME> where SITE is instagram/youtube/twitter/etc.
+# and HEADER_NAME uses underscores in place of hyphens. Values passed to
+# yt-dlp (--user-agent / --add-header) and gallery-dl (-o extractor.<site>.*).
+# Get exact values from your browser's DevTools on the platform you logged into.
+# INSTAGRAM_USER_AGENT=Mozilla/5.0 (...your browser UA...)
+# INSTAGRAM_ACCEPT_LANGUAGE=en-US,en;q=0.9
+# INSTAGRAM_SEC_CH_UA="Chromium";v="...", "Google Chrome";v="..."
+# INSTAGRAM_SEC_CH_UA_MOBILE=?0
+# INSTAGRAM_SEC_CH_UA_PLATFORM="macOS"
+# INSTAGRAM_X_IG_APP_ID=936619743392459

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  # Keeps the SHA-pinned actions in docker-build.yml current automatically
+  # (Dependabot bumps the pinned SHA + the `# vX` comment), so pinning doesn't
+  # become a manual-maintenance burden.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name == 'schedule'
         uses: lucacome/docker-image-update-checker@v2.0.0
         with:
-          base-image: "node:slim"
+          base-image: "node:22-slim"
           image: "realies/tgmr:latest"
         continue-on-error: true
 
@@ -31,8 +31,29 @@ jobs:
         run: echo "needs-updating=true" >> $GITHUB_OUTPUT
         id: force_update
 
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn build
+
   build:
-    needs: check_update
+    needs: [check_update, lint-and-typecheck]
     runs-on: ubuntu-latest
     if: needs.check_update.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch'
     

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name == 'schedule'
         uses: lucacome/docker-image-update-checker@v2.0.0
         with:
-          base-image: "node:22-slim"
+          base-image: "node:slim"
           image: "realies/tgmr:latest"
         continue-on-error: true
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,57 +1,73 @@
-name: "Build and Publish Docker Image"
+name: "CI / Build and Publish Docker Image"
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
-    - cron: "0 0 * * *"  # Run daily at midnight UTC
+    - cron: "0 0 * * *"  # Daily — rebuild to pull the latest gallery-dl / yt-dlp
   workflow_dispatch:  # Allow manual triggering
 
+# Least-privilege default: jobs only read the repo. The Docker push authenticates
+# with the DOCKER_* secrets, not GITHUB_TOKEN, so no write scopes are needed.
+permissions:
+  contents: read
+
 jobs:
-  check_update:
+  verify:
     runs-on: ubuntu-latest
-    outputs:
-      needs_update: ${{ steps.check_base_image.outputs.needs-updating }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Check if Base Image Updated
-        id: check_base_image
-        if: github.event_name == 'schedule'
-        uses: lucacome/docker-image-update-checker@v2.0.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          base-image: "node:slim"
-          image: "realies/tgmr:latest"
-        continue-on-error: true
+          persist-credentials: false
 
-      - name: Set needs_update for non-schedule events
-        if: github.event_name != 'schedule'
-        run: echo "needs-updating=true" >> $GITHUB_OUTPUT
-        id: force_update
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn build
+
+      - name: Test
+        run: yarn test
 
   build:
-    needs: check_update
+    needs: verify
+    # Build + publish on push / schedule / manual — never on pull_request (no
+    # registry push from PRs). The daily schedule always runs so BUILD_DATE
+    # refreshes gallery-dl / yt-dlp without manual pin bumps.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    if: needs.check_update.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch'
-    
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: realies/tgmr
           tags: |
@@ -59,7 +75,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -67,4 +83,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64 
+          platforms: linux/amd64,linux/arm64
+          # Unique per run → pipx install layer always rebuilds → daily cron
+          # ships fresh gallery-dl / yt-dlp without manual pin bumps.
+          build-args: |
+            BUILD_DATE=${{ github.run_id }}-${{ github.run_attempt }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ yarn-error.log
 
 # Build output
 dist/
+dist-test/
 
 # Environment variables
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim AS builder
+FROM node:slim AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY . .
 # Build TypeScript
 RUN yarn build
 
-FROM node:22-slim AS runner
+FROM node:slim AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim AS builder
+FROM node:22-slim AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY . .
 # Build TypeScript
 RUN yarn build
 
-FROM node:slim AS runner
+FROM node:22-slim AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:slim AS builder
 
 WORKDIR /app
 
+# node:slim no longer bundles Yarn — install the pinned classic line explicitly.
+RUN npm install -g yarn@1.22.22
+
 # Copy package files
 COPY package*.json yarn.lock ./
 
@@ -18,15 +21,24 @@ FROM node:slim AS runner
 
 WORKDIR /app
 
+# BUILD_DATE busts the pipx install layer cache — pass a fresh value
+# (e.g. `--build-arg BUILD_DATE=$(date -u +%Y-%m-%d)`) per rebuild so daily
+# CI builds always pull the latest gallery-dl / yt-dlp without manual pin bumps.
+ARG BUILD_DATE=unset
+
 # Install yt-dlp, gallery-dl, and ffmpeg
-RUN apt-get update && \
+RUN echo "Build date: ${BUILD_DATE}" && \
+    apt-get update && \
     apt-get install -y python3 python3-full pipx ffmpeg && \
     # Setup pipx for non-root user
     mkdir -p /home/node/.local/bin && \
     chown -R node:node /home/node/.local && \
-    # Switch to non-root user for pipx install
-    su node -c "pipx install yt-dlp" && \
-    su node -c "pipx install gallery-dl" && \
+    # Pin minimum versions known to handle the Apr-2026 Instagram 429 wave
+    # (gallery-dl 1.32 added user-cache + user-strategy; yt-dlp 2026.04 has the
+    # current Instagram extractor fixes). BUILD_DATE arg above ensures rebuilds
+    # actually fetch the latest patch releases instead of reusing this layer.
+    su node -c "pipx install 'gallery-dl>=1.32.0'" && \
+    su node -c "pipx install 'yt-dlp>=2026.4.4'" && \
     # Verify installations
     su node -c "/home/node/.local/bin/yt-dlp --version" && \
     su node -c "/home/node/.local/bin/gallery-dl --version" && \
@@ -38,7 +50,7 @@ RUN apt-get update && \
 # Copy built files and dependencies
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json /app/yarn.lock ./
-RUN yarn install --frozen-lockfile --production
+RUN npm install -g yarn@1.22.22 && yarn install --frozen-lockfile --production
 
 # Setup directories and permissions
 RUN mkdir -p /tmp/tgmr && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     container_name: tgmr
     image: realies/tgmr:latest
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 100
     env_file: .env
     environment:
       - BOT_TOKEN=${BOT_TOKEN:?Set BOT_TOKEN in .env}
@@ -17,4 +22,4 @@ services:
     volumes:
       - ./cookies:/cookies
     tmpfs:
-      - /tmp/tgmr:exec,size=1G
+      - /tmp/tgmr:noexec,nosuid,size=1G

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   tgmr:
     container_name: tgmr
-    image: realies/tgmr:latest
+    build: .
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -20,4 +20,4 @@ services:
     volumes:
       - ./cookies:/cookies
     tmpfs:
-      - /tmp/tgmr:noexec,nosuid,size=1G
+      - /tmp/tgmr:noexec,nosuid,size=1G,uid=1000,gid=1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   tgmr:
     container_name: tgmr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,24 @@
-version: '3.8'
-
 services:
   tgmr:
     container_name: tgmr
-    image: realies/tgmr:latest
+    build:
+      context: .
+      # Pass BUILD_DATE to bust the pipx install layer for fresh gallery-dl /
+      # yt-dlp. Default keeps the layer cache between rebuilds; for a forced
+      # refresh run: `BUILD_DATE=$(date -u +%s) docker compose up --build -d`.
+      args:
+        BUILD_DATE: ${BUILD_DATE:-static}
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 100
     env_file: .env
     environment:
       - BOT_TOKEN=${BOT_TOKEN:?Set BOT_TOKEN in .env}
-      - MAX_FILE_SIZE=${MAX_FILE_SIZE:-50000000}
-      - DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT:-300}
+      - MAX_FILE_SIZE=${MAX_FILE_SIZE:-52428800}
+      - DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT:-120}
       - RATE_LIMIT=${RATE_LIMIT:-10}
       - COOLDOWN=${COOLDOWN:-60}
       - TMP_DIR=${TMP_DIR:-/tmp/tgmr}
@@ -17,4 +26,6 @@ services:
     volumes:
       - ./cookies:/cookies
     tmpfs:
-      - /tmp/tgmr:exec,size=1G
+      # In-RAM scratch for downloads — sized for the on-disk cache (~512MB) plus
+      # a few concurrent downloads. Raise if you increase MAX_FILE_SIZE/limits.
+      - /tmp/tgmr:noexec,nosuid,size=2G,uid=1000,gid=1000

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/index.ts",
     "build": "tsc",
+    "test": "tsc -p tsconfig.test.json && BOT_TOKEN=test:token node --test 'dist-test/**/*.test.js'",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write 'src/**/*.ts'"

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -34,11 +34,12 @@ export async function createBot(): Promise<Bot> {
         try {
           const botMember = await ctx.api.getChatMember(chatId!, ctx.me.id);
           const canSendMessages =
+            botMember.status === 'creator' ||
             botMember.status === 'administrator' ||
             ('can_send_messages' in botMember && botMember.can_send_messages);
 
           if (!canSendMessages) {
-            logger.error(`Bot lacks message permissions in chat ${chatId}`);
+            logger.warn(`Bot lacks message permissions in chat ${chatId}`);
             return;
           }
         } catch (permError) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -6,17 +6,14 @@ import { logger } from '../utils/logger.js';
 import { getSupportedPlatforms } from '../utils/url.js';
 
 export async function createBot(): Promise<Bot> {
-  // Create tmp directory if it doesn't exist
   try {
-    await mkdir('./tmp', { recursive: true });
+    await mkdir(env.TMP_DIR, { recursive: true });
   } catch {
     // Ignore if directory already exists
   }
 
-  // Initialize bot
   const bot = new Bot(env.BOT_TOKEN);
 
-  // Set up command handlers
   bot.command('start', (ctx) =>
     ctx.reply(
       "Hello! I can help you download media from various platforms. Just send me a link, and I'll reply with the media.",
@@ -31,14 +28,12 @@ export async function createBot(): Promise<Bot> {
     ),
   );
 
-  // Handle all messages
   bot.on('message:text', async (ctx) => {
     try {
       const chatType = ctx.chat?.type;
       const messageText = ctx.message?.text;
       const chatId = ctx.chat?.id;
 
-      // For group chats, check if bot can send messages
       if (chatType === 'group' || chatType === 'supergroup') {
         try {
           const botMember = await ctx.api.getChatMember(chatId!, ctx.me.id);
@@ -51,32 +46,30 @@ export async function createBot(): Promise<Bot> {
             return;
           }
         } catch (permError) {
-          logger.error('Failed to check bot permissions:', permError);
+          logger.error('Failed to check bot permissions', { error: permError });
           return;
         }
       }
 
-      // Process URLs
       if (messageText?.includes('http')) {
         try {
           await handleMessage(ctx);
         } catch (error) {
-          logger.error('Error in handleMessage:', error);
+          logger.error('Error in handleMessage', { error });
           try {
             await ctx.reply('Sorry, there was an error processing your request. Please try again.');
           } catch (replyError) {
-            logger.error('Failed to send error message:', replyError);
+            logger.error('Failed to send error message', { error: replyError });
           }
         }
       }
     } catch (error) {
-      logger.error('Error in message handler:', error);
+      logger.error('Error in message handler', { error });
     }
   });
 
-  // Error handling
   bot.catch((err) => {
-    logger.error('Unhandled error in bot:', err);
+    logger.error('Unhandled error in bot', { error: err });
   });
 
   return bot;

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -9,6 +9,15 @@ import { getSupportedPlatforms } from '../utils/url.js';
 const PERMISSION_CACHE_TTL = 5 * 60 * 1000;
 const permissionCache = new Map<number, { canSend: boolean; expiry: number }>();
 
+// Periodically prune expired entries so the cache doesn't grow unbounded
+const pruneTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [chatId, entry] of permissionCache) {
+    if (now > entry.expiry) permissionCache.delete(chatId);
+  }
+}, PERMISSION_CACHE_TTL);
+pruneTimer.unref();
+
 function getCachedPermission(chatId: number): boolean | null {
   const cached = permissionCache.get(chatId);
   if (!cached || Date.now() > cached.expiry) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -5,6 +5,23 @@ import { mkdir } from 'fs/promises';
 import { logger } from '../utils/logger.js';
 import { getSupportedPlatforms } from '../utils/url.js';
 
+// Cache bot permission checks per chat (5-minute TTL)
+const PERMISSION_CACHE_TTL = 5 * 60 * 1000;
+const permissionCache = new Map<number, { canSend: boolean; expiry: number }>();
+
+function getCachedPermission(chatId: number): boolean | null {
+  const cached = permissionCache.get(chatId);
+  if (!cached || Date.now() > cached.expiry) {
+    permissionCache.delete(chatId);
+    return null;
+  }
+  return cached.canSend;
+}
+
+function cachePermission(chatId: number, canSend: boolean): void {
+  permissionCache.set(chatId, { canSend, expiry: Date.now() + PERMISSION_CACHE_TTL });
+}
+
 export async function createBot(): Promise<Bot> {
   await mkdir(env.TMP_DIR, { recursive: true });
 
@@ -30,34 +47,42 @@ export async function createBot(): Promise<Bot> {
       const messageText = ctx.message?.text;
       const chatId = ctx.chat?.id;
 
-      if (chatType === 'group' || chatType === 'supergroup') {
-        try {
-          const botMember = await ctx.api.getChatMember(chatId!, ctx.me.id);
-          const canSendMessages =
-            botMember.status === 'creator' ||
-            botMember.status === 'administrator' ||
-            ('can_send_messages' in botMember && botMember.can_send_messages);
+      // Skip early if no URL candidate
+      if (!messageText?.includes('http')) return;
 
-          if (!canSendMessages) {
-            logger.warn(`Bot lacks message permissions in chat ${chatId}`);
+      // Check bot permissions in groups (with cache)
+      if (chatId && (chatType === 'group' || chatType === 'supergroup')) {
+        const cached = getCachedPermission(chatId);
+        if (cached === false) return;
+
+        if (cached === null) {
+          try {
+            const botMember = await ctx.api.getChatMember(chatId, ctx.me.id);
+            const canSendMessages =
+              botMember.status === 'creator' ||
+              botMember.status === 'administrator' ||
+              ('can_send_messages' in botMember && botMember.can_send_messages);
+
+            cachePermission(chatId, canSendMessages);
+            if (!canSendMessages) {
+              logger.warn(`Bot lacks message permissions in chat ${chatId}`);
+              return;
+            }
+          } catch (permError) {
+            logger.error('Failed to check bot permissions', { error: permError });
             return;
           }
-        } catch (permError) {
-          logger.error('Failed to check bot permissions', { error: permError });
-          return;
         }
       }
 
-      if (messageText?.includes('http')) {
+      try {
+        await handleMessage(ctx);
+      } catch (error) {
+        logger.error('Error in handleMessage', { error });
         try {
-          await handleMessage(ctx);
-        } catch (error) {
-          logger.error('Error in handleMessage', { error });
-          try {
-            await ctx.reply('Sorry, there was an error processing your request. Please try again.');
-          } catch (replyError) {
-            logger.error('Failed to send error message', { error: replyError });
-          }
+          await ctx.reply('Sorry, there was an error processing your request. Please try again.');
+        } catch (replyError) {
+          logger.error('Failed to send error message', { error: replyError });
         }
       }
     } catch (error) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -6,11 +6,7 @@ import { logger } from '../utils/logger.js';
 import { getSupportedPlatforms } from '../utils/url.js';
 
 export async function createBot(): Promise<Bot> {
-  try {
-    await mkdir(env.TMP_DIR, { recursive: true });
-  } catch {
-    // Ignore if directory already exists
-  }
+  await mkdir(env.TMP_DIR, { recursive: true });
 
   const bot = new Bot(env.BOT_TOKEN);
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -5,18 +5,41 @@ import { mkdir } from 'fs/promises';
 import { logger } from '../utils/logger.js';
 import { getSupportedPlatforms } from '../utils/url.js';
 
-export async function createBot(): Promise<Bot> {
-  // Create tmp directory if it doesn't exist
-  try {
-    await mkdir('./tmp', { recursive: true });
-  } catch {
-    // Ignore if directory already exists
-  }
+// Cache bot permission checks per chat (5-minute TTL)
+const PERMISSION_CACHE_TTL = 5 * 60 * 1000;
+const permissionCache = new Map<number, { canSend: boolean; expiry: number }>();
 
-  // Initialize bot
+// Periodically prune expired entries so the cache doesn't grow unbounded
+const pruneTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [chatId, entry] of permissionCache) {
+    if (now > entry.expiry) permissionCache.delete(chatId);
+  }
+}, PERMISSION_CACHE_TTL);
+pruneTimer.unref();
+
+export function stopPermissionPrune(): void {
+  clearInterval(pruneTimer);
+}
+
+function getCachedPermission(chatId: number): boolean | null {
+  const cached = permissionCache.get(chatId);
+  if (!cached || Date.now() > cached.expiry) {
+    permissionCache.delete(chatId);
+    return null;
+  }
+  return cached.canSend;
+}
+
+function cachePermission(chatId: number, canSend: boolean): void {
+  permissionCache.set(chatId, { canSend, expiry: Date.now() + PERMISSION_CACHE_TTL });
+}
+
+export async function createBot(): Promise<Bot> {
+  await mkdir(env.TMP_DIR, { recursive: true });
+
   const bot = new Bot(env.BOT_TOKEN);
 
-  // Set up command handlers
   bot.command('start', (ctx) =>
     ctx.reply(
       "Hello! I can help you download media from various platforms. Just send me a link, and I'll reply with the media.",
@@ -31,52 +54,62 @@ export async function createBot(): Promise<Bot> {
     ),
   );
 
-  // Handle all messages
   bot.on('message:text', async (ctx) => {
     try {
       const chatType = ctx.chat?.type;
       const messageText = ctx.message?.text;
       const chatId = ctx.chat?.id;
 
-      // For group chats, check if bot can send messages
-      if (chatType === 'group' || chatType === 'supergroup') {
-        try {
-          const botMember = await ctx.api.getChatMember(chatId!, ctx.me.id);
-          const canSendMessages =
-            botMember.status === 'administrator' ||
-            ('can_send_messages' in botMember && botMember.can_send_messages);
+      // Skip early if no URL candidate
+      if (!messageText?.includes('http')) return;
 
-          if (!canSendMessages) {
-            logger.error(`Bot lacks message permissions in chat ${chatId}`);
+      // Check bot permissions in groups (with cache)
+      if (chatId && (chatType === 'group' || chatType === 'supergroup')) {
+        const cached = getCachedPermission(chatId);
+        if (cached === false) return;
+
+        if (cached === null) {
+          try {
+            const botMember = await ctx.api.getChatMember(chatId, ctx.me.id);
+            // creator/administrator/member can send by default; only the
+            // 'restricted' status carries an explicit can_send_messages flag.
+            // Telegram omits it for a plain 'member', so treating its absence as
+            // "no permission" would make the bot silently ignore non-admin groups.
+            const canSendMessages =
+              botMember.status === 'creator' ||
+              botMember.status === 'administrator' ||
+              botMember.status === 'member' ||
+              (botMember.status === 'restricted' && botMember.can_send_messages === true);
+
+            cachePermission(chatId, canSendMessages);
+            if (!canSendMessages) {
+              logger.warn(`Bot lacks message permissions in chat ${chatId}`);
+              return;
+            }
+          } catch (permError) {
+            logger.error('Failed to check bot permissions', { error: permError });
             return;
           }
-        } catch (permError) {
-          logger.error('Failed to check bot permissions:', permError);
-          return;
         }
       }
 
-      // Process URLs
-      if (messageText?.includes('http')) {
+      try {
+        await handleMessage(ctx);
+      } catch (error) {
+        logger.error('Error in handleMessage', { error });
         try {
-          await handleMessage(ctx);
-        } catch (error) {
-          logger.error('Error in handleMessage:', error);
-          try {
-            await ctx.reply('Sorry, there was an error processing your request. Please try again.');
-          } catch (replyError) {
-            logger.error('Failed to send error message:', replyError);
-          }
+          await ctx.reply('Sorry, there was an error processing your request. Please try again.');
+        } catch (replyError) {
+          logger.error('Failed to send error message', { error: replyError });
         }
       }
     } catch (error) {
-      logger.error('Error in message handler:', error);
+      logger.error('Error in message handler', { error });
     }
   });
 
-  // Error handling
   bot.catch((err) => {
-    logger.error('Unhandled error in bot:', err);
+    logger.error('Unhandled error in bot', { error: err.error });
   });
 
   return bot;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,45 +1,42 @@
+// Validate required environment variables before exporting
+const BOT_TOKEN = process.env.BOT_TOKEN;
+if (!BOT_TOKEN) {
+  throw new Error('BOT_TOKEN environment variable is required');
+}
+
 export const env = {
-  BOT_TOKEN: process.env.BOT_TOKEN as string,
+  BOT_TOKEN,
   MAX_FILE_SIZE: parseInt(process.env.MAX_FILE_SIZE || '50000000', 10),
   DOWNLOAD_TIMEOUT: parseInt(process.env.DOWNLOAD_TIMEOUT || '300', 10),
   RATE_LIMIT: parseInt(process.env.RATE_LIMIT || '10', 10),
   COOLDOWN: parseInt(process.env.COOLDOWN || '60', 10),
   TMP_DIR: process.env.TMP_DIR || './tmp',
-  SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be').split(','),
+  SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be')
+    .split(',')
+    .map((d) => d.trim())
+    .filter(Boolean),
 } as const;
 
-// Map domain patterns to their cookie files
-export const getCookieFileForDomain = (domain: string): string | null => {
-  // Get all environment variables starting with COOKIES_FILE_
-  const cookieEnvVars = Object.entries(process.env)
-    .filter(([key]) => key.startsWith('COOKIES_FILE_'))
-    .map(([key, value]) => ({
-      site: key.replace('COOKIES_FILE_', '').toLowerCase(),
-      path: value,
-    }));
+// Build cookie file lookup map once at startup
+const cookieFileMap = new Map<string, string>();
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith('COOKIES_FILE_') && value) {
+    cookieFileMap.set(key.replace('COOKIES_FILE_', '').toLowerCase(), value);
+  }
+}
+const defaultCookieFile = process.env.COOKIES_FILE || null;
 
-  // Find matching cookie file based on domain
-  for (const { site, path } of cookieEnvVars) {
-    // Handle special cases
-    switch (site) {
-      case 'youtube':
-        if (domain === 'youtube.com' || domain === 'youtu.be') return path || null;
-        break;
-      case 'twitter':
-      case 'x':
-        if (domain === 'twitter.com' || domain === 'x.com') return path || null;
-        break;
-      default:
-        // For other sites, match the domain directly
-        if (domain === `${site}.com` || domain === site) return path || null;
+export const getCookieFileForDomain = (domain: string): string | null => {
+  if (domain === 'youtube.com' || domain === 'youtu.be') {
+    return cookieFileMap.get('youtube') || defaultCookieFile;
+  }
+  if (domain === 'twitter.com' || domain === 'x.com') {
+    return cookieFileMap.get('twitter') || cookieFileMap.get('x') || defaultCookieFile;
+  }
+  for (const [site, path] of cookieFileMap) {
+    if (domain === `${site}.com` || domain === site) {
+      return path;
     }
   }
-
-  // Fallback to default cookies file if specified
-  return process.env.COOKIES_FILE || null;
+  return defaultCookieFile;
 };
-
-// Validate required environment variables
-if (!env.BOT_TOKEN) {
-  throw new Error('BOT_TOKEN environment variable is required');
-}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -21,7 +21,7 @@ export const env = {
   TMP_DIR: process.env.TMP_DIR || './tmp',
   SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be')
     .split(',')
-    .map((d) => d.trim())
+    .map((d) => d.trim().toLowerCase())
     .filter(Boolean),
 } as const;
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,15 +1,23 @@
-// Validate required environment variables before exporting
 const BOT_TOKEN = process.env.BOT_TOKEN;
 if (!BOT_TOKEN) {
   throw new Error('BOT_TOKEN environment variable is required');
 }
 
+function requirePositiveInt(name: string, raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const val = parseInt(raw, 10);
+  if (!Number.isFinite(val) || val <= 0) {
+    throw new Error(`${name} must be a positive integer, got: "${raw}"`);
+  }
+  return val;
+}
+
 export const env = {
   BOT_TOKEN,
-  MAX_FILE_SIZE: parseInt(process.env.MAX_FILE_SIZE || '50000000', 10),
-  DOWNLOAD_TIMEOUT: parseInt(process.env.DOWNLOAD_TIMEOUT || '300', 10),
-  RATE_LIMIT: parseInt(process.env.RATE_LIMIT || '10', 10),
-  COOLDOWN: parseInt(process.env.COOLDOWN || '60', 10),
+  MAX_FILE_SIZE: requirePositiveInt('MAX_FILE_SIZE', process.env.MAX_FILE_SIZE, 50_000_000),
+  DOWNLOAD_TIMEOUT: requirePositiveInt('DOWNLOAD_TIMEOUT', process.env.DOWNLOAD_TIMEOUT, 300),
+  RATE_LIMIT: requirePositiveInt('RATE_LIMIT', process.env.RATE_LIMIT, 10),
+  COOLDOWN: requirePositiveInt('COOLDOWN', process.env.COOLDOWN, 60),
   TMP_DIR: process.env.TMP_DIR || './tmp',
   SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be')
     .split(',')
@@ -26,12 +34,18 @@ for (const [key, value] of Object.entries(process.env)) {
 }
 const defaultCookieFile = process.env.COOKIES_FILE || null;
 
+// Domain alias map for cookie resolution
+const COOKIE_DOMAIN_ALIASES: Record<string, string> = {
+  'youtu.be': 'youtube',
+  'youtube.com': 'youtube',
+  'twitter.com': 'twitter',
+  'x.com': 'twitter',
+};
+
 export const getCookieFileForDomain = (domain: string): string | null => {
-  if (domain === 'youtube.com' || domain === 'youtu.be') {
-    return cookieFileMap.get('youtube') || defaultCookieFile;
-  }
-  if (domain === 'twitter.com' || domain === 'x.com') {
-    return cookieFileMap.get('twitter') || cookieFileMap.get('x') || defaultCookieFile;
+  const alias = COOKIE_DOMAIN_ALIASES[domain];
+  if (alias) {
+    return cookieFileMap.get(alias) || defaultCookieFile;
   }
   for (const [site, path] of cookieFileMap) {
     if (domain === `${site}.com` || domain === site) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,5 @@
+import { resolve, isAbsolute } from 'path';
+
 const BOT_TOKEN = process.env.BOT_TOKEN;
 if (!BOT_TOKEN) {
   throw new Error('BOT_TOKEN environment variable is required');
@@ -18,39 +20,55 @@ export const env = {
   DOWNLOAD_TIMEOUT: requirePositiveInt('DOWNLOAD_TIMEOUT', process.env.DOWNLOAD_TIMEOUT, 300),
   RATE_LIMIT: requirePositiveInt('RATE_LIMIT', process.env.RATE_LIMIT, 10),
   COOLDOWN: requirePositiveInt('COOLDOWN', process.env.COOLDOWN, 60),
-  TMP_DIR: process.env.TMP_DIR || './tmp',
+  TMP_DIR: resolve(process.env.TMP_DIR || './tmp'),
   SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be')
     .split(',')
     .map((d) => d.trim().toLowerCase())
     .filter(Boolean),
 } as const;
 
-// Build cookie file lookup map once at startup
+// Build cookie file lookup map once at startup, with validation
 const cookieFileMap = new Map<string, string>();
 for (const [key, value] of Object.entries(process.env)) {
   if (key.startsWith('COOKIES_FILE_') && value) {
+    if (!isAbsolute(value)) {
+      throw new Error(`${key} must be an absolute path, got: "${value}"`);
+    }
     cookieFileMap.set(key.replace('COOKIES_FILE_', '').toLowerCase(), value);
   }
 }
-const defaultCookieFile = process.env.COOKIES_FILE || null;
+const defaultCookieFile = process.env.COOKIES_FILE
+  ? (() => {
+      if (!isAbsolute(process.env.COOKIES_FILE!)) {
+        throw new Error(
+          `COOKIES_FILE must be an absolute path, got: "${process.env.COOKIES_FILE}"`,
+        );
+      }
+      return process.env.COOKIES_FILE!;
+    })()
+  : null;
 
-// Domain alias map for cookie resolution
+// Declarative domain-to-cookie-key alias map
 const COOKIE_DOMAIN_ALIASES: Record<string, string> = {
   'youtu.be': 'youtube',
   'youtube.com': 'youtube',
   'twitter.com': 'twitter',
   'x.com': 'twitter',
+  'instagram.com': 'instagram',
+  'facebook.com': 'facebook',
+  'soundcloud.com': 'soundcloud',
+  'bandcamp.com': 'bandcamp',
+  'vimeo.com': 'vimeo',
+  'mixcloud.com': 'mixcloud',
+  'pixiv.net': 'pixiv',
+  'deviantart.com': 'deviantart',
+  'artstation.com': 'artstation',
 };
 
 export const getCookieFileForDomain = (domain: string): string | null => {
   const alias = COOKIE_DOMAIN_ALIASES[domain];
   if (alias) {
     return cookieFileMap.get(alias) || defaultCookieFile;
-  }
-  for (const [site, path] of cookieFileMap) {
-    if (domain === `${site}.com` || domain === site) {
-      return path;
-    }
   }
   return defaultCookieFile;
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,45 +1,137 @@
-export const env = {
-  BOT_TOKEN: process.env.BOT_TOKEN as string,
-  MAX_FILE_SIZE: parseInt(process.env.MAX_FILE_SIZE || '50000000', 10),
-  DOWNLOAD_TIMEOUT: parseInt(process.env.DOWNLOAD_TIMEOUT || '300', 10),
-  RATE_LIMIT: parseInt(process.env.RATE_LIMIT || '10', 10),
-  COOLDOWN: parseInt(process.env.COOLDOWN || '60', 10),
-  TMP_DIR: process.env.TMP_DIR || './tmp',
-  SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be').split(','),
-} as const;
+import { resolve, isAbsolute } from 'path';
 
-// Map domain patterns to their cookie files
-export const getCookieFileForDomain = (domain: string): string | null => {
-  // Get all environment variables starting with COOKIES_FILE_
-  const cookieEnvVars = Object.entries(process.env)
-    .filter(([key]) => key.startsWith('COOKIES_FILE_'))
-    .map(([key, value]) => ({
-      site: key.replace('COOKIES_FILE_', '').toLowerCase(),
-      path: value,
-    }));
-
-  // Find matching cookie file based on domain
-  for (const { site, path } of cookieEnvVars) {
-    // Handle special cases
-    switch (site) {
-      case 'youtube':
-        if (domain === 'youtube.com' || domain === 'youtu.be') return path || null;
-        break;
-      case 'twitter':
-      case 'x':
-        if (domain === 'twitter.com' || domain === 'x.com') return path || null;
-        break;
-      default:
-        // For other sites, match the domain directly
-        if (domain === `${site}.com` || domain === site) return path || null;
-    }
-  }
-
-  // Fallback to default cookies file if specified
-  return process.env.COOKIES_FILE || null;
-};
-
-// Validate required environment variables
-if (!env.BOT_TOKEN) {
+const BOT_TOKEN = process.env.BOT_TOKEN;
+if (!BOT_TOKEN) {
   throw new Error('BOT_TOKEN environment variable is required');
 }
+
+function requirePositiveInt(name: string, raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  // Reject partially-numeric typos like "60s" or "10MB" — parseInt would
+  // silently accept them. Require a positive decimal integer.
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be a positive integer, got: "${raw}"`);
+  }
+  const val = Number(raw);
+  if (val <= 0) {
+    throw new Error(`${name} must be a positive integer, got: "${raw}"`);
+  }
+  return val;
+}
+
+export const env = {
+  BOT_TOKEN,
+  MAX_FILE_SIZE: requirePositiveInt('MAX_FILE_SIZE', process.env.MAX_FILE_SIZE, 50 * 1024 * 1024),
+  DOWNLOAD_TIMEOUT: requirePositiveInt('DOWNLOAD_TIMEOUT', process.env.DOWNLOAD_TIMEOUT, 120),
+  RATE_LIMIT: requirePositiveInt('RATE_LIMIT', process.env.RATE_LIMIT, 10),
+  COOLDOWN: requirePositiveInt('COOLDOWN', process.env.COOLDOWN, 60),
+  TMP_DIR: resolve(process.env.TMP_DIR || './tmp'),
+  SUPPORTED_DOMAINS: (process.env.SUPPORTED_DOMAINS || 'youtube.com,youtu.be')
+    .split(',')
+    .map((d) => d.trim().toLowerCase())
+    .filter(Boolean),
+} as const;
+
+// Build cookie file lookup map once at startup, with validation
+const cookieFileMap = new Map<string, string>();
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith('COOKIES_FILE_') && value) {
+    if (!isAbsolute(value)) {
+      throw new Error(`${key} must be an absolute path, got: "${value}"`);
+    }
+    cookieFileMap.set(key.replace('COOKIES_FILE_', '').toLowerCase(), value);
+  }
+}
+const defaultCookieFile = process.env.COOKIES_FILE
+  ? ((): string => {
+      if (!isAbsolute(process.env.COOKIES_FILE!)) {
+        throw new Error(
+          `COOKIES_FILE must be an absolute path, got: "${process.env.COOKIES_FILE}"`,
+        );
+      }
+      return process.env.COOKIES_FILE!;
+    })()
+  : null;
+
+// Unified site registry: each supported domain maps to an alias (cookie
+// env-var key + gallery-dl extractor name) and a content type that drives
+// download routing — 'image' sites use gallery-dl for images with yt-dlp
+// fallback for video items; 'video' sites go straight to yt-dlp.
+export interface SiteEntry {
+  readonly alias: string;
+  readonly type: 'image' | 'video';
+}
+
+const SITES: Readonly<Record<string, SiteEntry>> = {
+  // Video-first platforms
+  'youtu.be': { alias: 'youtube', type: 'video' },
+  'youtube.com': { alias: 'youtube', type: 'video' },
+  'facebook.com': { alias: 'facebook', type: 'video' },
+  'soundcloud.com': { alias: 'soundcloud', type: 'video' },
+  'bandcamp.com': { alias: 'bandcamp', type: 'video' },
+  'vimeo.com': { alias: 'vimeo', type: 'video' },
+  'mixcloud.com': { alias: 'mixcloud', type: 'video' },
+  // Image-first platforms (gallery-dl, with yt-dlp for any video items)
+  'instagram.com': { alias: 'instagram', type: 'image' },
+  'twitter.com': { alias: 'twitter', type: 'image' },
+  'x.com': { alias: 'twitter', type: 'image' },
+  'pixiv.net': { alias: 'pixiv', type: 'image' },
+  'deviantart.com': { alias: 'deviantart', type: 'image' },
+  'artstation.com': { alias: 'artstation', type: 'image' },
+};
+
+// Matches exact hostname or any subdomain (duplicated from url.ts to avoid
+// a circular import — url.ts imports env).
+const domainMatches = (hostname: string, site: string): boolean =>
+  hostname === site || hostname.endsWith(`.${site}`);
+
+/**
+ * Finds the site entry (alias + content type) for a domain. Matches exact
+ * hostname or any subdomain (e.g. music.youtube.com → youtube).
+ */
+export const findSiteByDomain = (domain: string): SiteEntry | null => {
+  const exact = SITES[domain];
+  if (exact) return exact;
+  for (const [siteDomain, entry] of Object.entries(SITES)) {
+    if (domainMatches(domain, siteDomain)) return entry;
+  }
+  return null;
+};
+
+export const getCookieFileForDomain = (domain: string): string | null => {
+  const site = findSiteByDomain(domain);
+  if (site) return cookieFileMap.get(site.alias) || defaultCookieFile;
+  return defaultCookieFile;
+};
+
+// Per-site request headers, keyed by site alias (e.g. 'instagram').
+// Parsed from env vars like INSTAGRAM_USER_AGENT, INSTAGRAM_SEC_CH_UA, etc.
+// Suffixes reserved for other config (COOKIES_FILE) are ignored. Invalid
+// header names are rejected. Helps keep sessions fresh by matching the
+// browser fingerprint that exported the cookies.
+const RESERVED_SUFFIXES = new Set(['COOKIES_FILE']);
+const HEADER_NAME_PATTERN = /^[a-z0-9-]+$/;
+const siteHeadersMap = new Map<string, Record<string, string>>();
+const knownSiteAliases = new Set(Object.values(SITES).map((s) => s.alias));
+
+// Iterate sites → env vars (not the reverse) so collision-avoidance is explicit
+for (const site of knownSiteAliases) {
+  const prefix = `${site.toUpperCase()}_`;
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!value || !key.startsWith(prefix)) continue;
+    const suffix = key.slice(prefix.length);
+    if (!suffix || RESERVED_SUFFIXES.has(suffix)) continue;
+    const headerName = suffix.replace(/_/g, '-').toLowerCase();
+    if (!HEADER_NAME_PATTERN.test(headerName)) continue;
+    headers[headerName] = value;
+  }
+  if (Object.keys(headers).length > 0) siteHeadersMap.set(site, headers);
+}
+
+export const getSiteHeaders = (domain: string): Record<string, string> => {
+  const site = findSiteByDomain(domain);
+  if (!site) return {};
+  // Shallow copy so a caller mutating the result can't leak into the shared cache.
+  return { ...(siteHeadersMap.get(site.alias) ?? {}) };
+};

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -16,7 +16,9 @@ import type { ChatAction } from '../utils/chatAction.js';
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
+const MAX_CONCURRENT_PROBES = 10;
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
+const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
 const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
@@ -218,46 +220,56 @@ async function buildMediaItems(
   logContext: Record<string, unknown>,
   requestId: string,
 ): Promise<MediaItem[]> {
-  return Promise.all(
-    filePaths.map(async (path) => {
-      assertSafePath(path, env.TMP_DIR);
-      const probe = await probeMediaFile(path);
+  // Use allSettled + semaphore so all probes complete before cleanup,
+  // and concurrent ffprobe/ffmpeg processes are bounded
+  const results = await Promise.allSettled(
+    filePaths.map((path) =>
+      probeSemaphore.run(async () => {
+        assertSafePath(path, env.TMP_DIR);
+        const probe = await probeMediaFile(path);
 
-      const isVideo = probe.streams.some(
-        (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
-      );
-
-      let thumbnail: Buffer | null = null;
-      if (isVideo) {
-        logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
-        thumbnail = await generateThumbnail(path);
-        if (thumbnail) {
-          logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
-        }
-      }
-
-      const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
-      const fileSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
-      const fileSizeMB =
-        Number.isFinite(fileSize) && fileSize > 0 ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
-
-      if (Number.isFinite(fileSize) && fileSize > env.MAX_FILE_SIZE) {
-        throw new Error(
-          `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
+        const isVideo = probe.streams.some(
+          (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
         );
-      }
 
-      return {
-        path,
-        isVideo,
-        thumbnail: thumbnail ?? undefined,
-        videoWidth: width,
-        videoHeight: height,
-        streamInfo: info,
-        fileSizeMB,
-      };
-    }),
+        let thumbnail: Buffer | null = null;
+        if (isVideo) {
+          logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
+          thumbnail = await generateThumbnail(path);
+          if (thumbnail) {
+            logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
+          }
+        }
+
+        const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
+        const fileSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
+        const fileSizeMB =
+          Number.isFinite(fileSize) && fileSize > 0 ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
+
+        if (Number.isFinite(fileSize) && fileSize > env.MAX_FILE_SIZE) {
+          throw new Error(
+            `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
+          );
+        }
+
+        return {
+          path,
+          isVideo,
+          thumbnail: thumbnail ?? undefined,
+          videoWidth: width,
+          videoHeight: height,
+          streamInfo: info,
+          fileSizeMB,
+        };
+      }),
+    ),
   );
+
+  // If any probe failed, throw the first error (after all have settled)
+  const rejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+  if (rejected) throw rejected.reason;
+
+  return results.map((r) => (r as PromiseFulfilledResult<MediaItem>).value);
 }
 
 // --- Telegram Send ---

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,21 +1,26 @@
 import { Context, InputFile } from 'grammy';
-import { readFile, stat } from 'fs/promises';
+import { readFile, stat, unlink } from 'fs/promises';
 import { isValidUrl, isSupportedPlatform } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
+import type { MediaMetadata } from '../services/downloader.js';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
 import { RateLimiter } from '../utils/rateLimit.js';
 import { safeExec } from '../utils/exec.js';
 import { assertSafePath } from '../utils/pathSafety.js';
-import { escapeMarkdownV2, normalizeLineBreaks } from '../utils/markdown.js';
+import { escapeMarkdownV2, escapeMarkdownV2Url, normalizeLineBreaks } from '../utils/markdown.js';
 import { Semaphore } from '../utils/concurrency.js';
 
 const THUMBNAIL_MAX_BYTES = 200 * 1024;
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
+const MAX_CONCURRENT_PROBES = 10;
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
+const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
+
+const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
 type ChatAction = 'typing' | 'upload_photo' | 'upload_video' | 'upload_voice' | 'upload_document';
 
@@ -48,6 +53,7 @@ interface MediaItem {
 class ChatActionManager {
   private timer: NodeJS.Timeout | null = null;
   private inFlight = false;
+  private stopped = false;
 
   constructor(
     private ctx: Context,
@@ -56,6 +62,7 @@ class ChatActionManager {
 
   async start(action: ChatAction): Promise<void> {
     this.stop();
+    this.stopped = false;
     try {
       await this.sendAction(action);
     } catch (error) {
@@ -66,8 +73,9 @@ class ChatActionManager {
   }
 
   private scheduleNext(action: ChatAction): void {
+    if (this.stopped) return;
     this.timer = setTimeout(async () => {
-      if (this.inFlight) return;
+      if (this.inFlight || this.stopped) return;
       this.inFlight = true;
       try {
         await this.sendAction(action);
@@ -77,7 +85,7 @@ class ChatActionManager {
         }
       } finally {
         this.inFlight = false;
-        if (this.timer !== null) this.scheduleNext(action);
+        if (!this.stopped) this.scheduleNext(action);
       }
     }, 1000);
   }
@@ -91,6 +99,7 @@ class ChatActionManager {
   }
 
   stop(): void {
+    this.stopped = true;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
@@ -119,6 +128,7 @@ async function probeMediaFile(path: string): Promise<FFprobeData> {
 
 async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
   const thumbnailPath = `${videoPath}.thumb.jpg`;
+  assertSafePath(thumbnailPath, env.TMP_DIR);
   try {
     await safeExec('ffmpeg', [
       '-y',
@@ -133,7 +143,10 @@ async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
       thumbnailPath,
     ]);
     const stats = await stat(thumbnailPath);
-    if (stats.size === 0 || stats.size > THUMBNAIL_MAX_BYTES) return null;
+    if (stats.size === 0 || stats.size > THUMBNAIL_MAX_BYTES) {
+      await unlink(thumbnailPath).catch(() => {});
+      return null;
+    }
     return await readFile(thumbnailPath);
   } catch {
     return null;
@@ -152,22 +165,22 @@ function extractStreamInfo(
   const parts = streams
     .map((stream) => {
       if (stream.codec_type === 'video') {
-        if (!isVideo) return `${stream.codec_name} ${stream.width}x${stream.height}`;
+        if (!isVideo) return `${stream.codec_name} ${stream.width ?? '?'}x${stream.height ?? '?'}`;
         const bitrate = stream.bit_rate
-          ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
+          ? `${Math.round(parseInt(stream.bit_rate, 10) / 1000)}kbps`
           : format?.bit_rate
-            ? `${Math.round(parseInt(format.bit_rate) / 1000)}kbps`
+            ? `${Math.round(parseInt(format.bit_rate, 10) / 1000)}kbps`
             : '';
-        return `${stream.codec_name} ${stream.width}x${stream.height}${bitrate ? ` ${bitrate}` : ''}`;
+        return `${stream.codec_name} ${stream.width ?? '?'}x${stream.height ?? '?'}${bitrate ? ` ${bitrate}` : ''}`;
       }
       if (stream.codec_type === 'audio') {
         const bitrate = stream.bit_rate
-          ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
+          ? `${Math.round(parseInt(stream.bit_rate, 10) / 1000)}kbps`
           : format?.bit_rate
-            ? `${Math.round(parseInt(format.bit_rate) / 1000)}kbps`
+            ? `${Math.round(parseInt(format.bit_rate, 10) / 1000)}kbps`
             : '';
         const sampleRate = stream.sample_rate
-          ? `${Math.round(parseInt(stream.sample_rate) / 1000)}kHz`
+          ? `${Math.round(parseInt(stream.sample_rate, 10) / 1000)}kHz`
           : '';
         return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
       }
@@ -183,7 +196,7 @@ function extractStreamInfo(
 
 function buildSingleCaption(title: string, url: string, item: MediaItem): string {
   const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
-  const escapedUrl = escapeMarkdownV2(url);
+  const escapedUrl = escapeMarkdownV2Url(url);
   const escapedInfo = escapeMarkdownV2(item.streamInfo);
   const escapedSize = escapeMarkdownV2(item.fileSizeMB);
   return `[${escapedTitle}](${escapedUrl})\n\`${escapedInfo}, ${escapedSize}MB\``;
@@ -195,19 +208,22 @@ function buildGroupCaption(
   chunk: MediaItem[],
   isFirstChunk: boolean,
 ): string {
-  const imageFormats = new Map<string, { count: number; dimensions: string }>();
-  const videoFormats = new Map<string, { count: number; dimensions: string; codec: string }>();
+  const imageFormats = new Map<string, { count: number; codec: string; dims: string }>();
+  const videoFormats = new Map<string, { count: number; codec: string; dims: string }>();
   let chunkTotalSize = 0;
 
   for (const item of chunk) {
+    const parts = item.streamInfo.split(' ');
+    const codec = parts[0] || 'unknown';
+    const dims = parts[1] || 'unknown';
+    const key = `${codec}-${dims}`;
+
     if (item.isVideo) {
-      const [codec, dimensions] = item.streamInfo.split(' ');
-      const existing = videoFormats.get(dimensions) || { count: 0, dimensions, codec };
-      videoFormats.set(dimensions, { ...existing, count: existing.count + 1 });
+      const existing = videoFormats.get(key) || { count: 0, codec, dims };
+      videoFormats.set(key, { ...existing, count: existing.count + 1 });
     } else {
-      const dimensions = item.streamInfo;
-      const existing = imageFormats.get(dimensions) || { count: 0, dimensions };
-      imageFormats.set(dimensions, { ...existing, count: existing.count + 1 });
+      const existing = imageFormats.get(key) || { count: 0, codec, dims };
+      imageFormats.set(key, { ...existing, count: existing.count + 1 });
     }
     chunkTotalSize += parseFloat(item.fileSizeMB);
   }
@@ -215,19 +231,13 @@ function buildGroupCaption(
   const formatParts: string[] = [];
   if (imageFormats.size > 0) {
     const summary = Array.from(imageFormats.values())
-      .map((info) => {
-        const [codec, dims] = info.dimensions.split(' ');
-        return `${info.count} ${codec} image${info.count > 1 ? 's' : ''} at ${dims}`;
-      })
+      .map((i) => `${i.count} ${i.codec} image${i.count > 1 ? 's' : ''} at ${i.dims}`)
       .join(', ');
     formatParts.push(summary);
   }
   if (videoFormats.size > 0) {
     const summary = Array.from(videoFormats.values())
-      .map(
-        (info) =>
-          `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
-      )
+      .map((i) => `${i.count} ${i.codec} video${i.count > 1 ? 's' : ''} at ${i.dims}`)
       .join(', ');
     formatParts.push(summary);
   }
@@ -238,10 +248,44 @@ function buildGroupCaption(
 
   if (isFirstChunk) {
     const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
-    const escapedUrl = escapeMarkdownV2(url);
+    const escapedUrl = escapeMarkdownV2Url(url);
     return `[${escapedTitle}](${escapedUrl})\n${sizeLabel}`;
   }
   return sizeLabel;
+}
+
+// --- Cleanup Helper ---
+
+async function cleanupFiles(
+  filePaths: string[],
+  mediaItems: MediaItem[],
+  downloader: MediaDownloader,
+  logContext: Record<string, unknown>,
+  requestId: string,
+): Promise<void> {
+  const pathsToClean = new Set<string>();
+
+  // Add raw download paths (covers case where buildMediaItems fails)
+  for (const p of filePaths) {
+    pathsToClean.add(p);
+    pathsToClean.add(`${p}.thumb.jpg`);
+  }
+
+  // Add media item paths (may include thumbnails)
+  for (const item of mediaItems) {
+    pathsToClean.add(item.path);
+    if (item.isVideo) pathsToClean.add(`${item.path}.thumb.jpg`);
+  }
+
+  await Promise.all(
+    Array.from(pathsToClean).map((file) =>
+      downloader
+        .cleanup(file)
+        .catch((error) =>
+          logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
+        ),
+    ),
+  );
 }
 
 // --- Main Handler ---
@@ -268,31 +312,33 @@ export async function handleMessage(ctx: Context): Promise<void> {
       : `user ${userId}`;
   const requestId = `[${chatId}:${messageId}]`;
 
-  if (!messageText || !chatId) {
-    logger.warn('Skipping message due to missing text or chatId', logContext);
+  if (!messageText || !chatId || !messageId) {
+    logger.warn('Skipping message due to missing text, chatId, or messageId', logContext);
     return;
   }
 
-  if (userId && !isAnonymousAdmin) {
-    if (!RateLimiter.getInstance().tryConsume(userId)) {
-      logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
-      await ctx.reply('You are sending requests too quickly. Please try again later.', {
-        reply_to_message_id: messageId,
-      });
-      return;
-    }
-  }
-
   try {
+    // Extract URLs first — only consume rate limit if there's a supported URL
     const words = messageText.split(/\s+/);
     const urls = words.filter((word) => isValidUrl(word) && isSupportedPlatform(word));
     if (urls.length === 0) return;
+
+    // Rate limit check AFTER URL extraction (non-URL messages don't count)
+    if (userId && !isAnonymousAdmin) {
+      if (!RateLimiter.getInstance().tryConsume(userId)) {
+        logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
+        await ctx.reply('You are sending requests too quickly. Please try again later.', {
+          reply_to_message_id: messageId,
+        });
+        return;
+      }
+    }
 
     const url = urls[0];
     logger.info(`${userInfo} requested: ${url}`, { ...logContext, requestId });
 
     await downloadSemaphore.run(() =>
-      processMediaRequest(ctx, url, chatId, messageId!, logContext, requestId, userInfo),
+      processMediaRequest(ctx, url, chatId, messageId, logContext, requestId, userInfo),
     );
   } catch (error) {
     logger.error('Failed to process message', { error });
@@ -311,19 +357,27 @@ async function processMediaRequest(
 ): Promise<void> {
   const downloader = MediaDownloader.getInstance();
   const actionManager = new ChatActionManager(ctx, chatId);
+  let filePaths: string[] = [];
+  let mediaItems: MediaItem[] = [];
 
   try {
     await actionManager.start('typing');
 
+    // Get media info — throws on failure for withRetry to retry
     logger.info('Fetching media info...', { ...logContext, requestId });
-    const mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
-      maxAttempts: 5,
-      initialDelay: 2000,
-      maxDelay: 15000,
-    });
-
-    if (!mediaInfo) {
-      logger.warn('Failed to get media information after retries', { ...logContext, requestId });
+    let mediaInfo: MediaMetadata;
+    try {
+      mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
+        maxAttempts: 5,
+        initialDelay: 2000,
+        maxDelay: 15000,
+      });
+    } catch (error) {
+      logger.warn('Failed to get media information after retries', {
+        ...logContext,
+        requestId,
+        error,
+      });
       await ctx.reply('Failed to get media information after several attempts', {
         reply_to_message_id: messageId,
       });
@@ -338,6 +392,7 @@ async function processMediaRequest(
           : 'upload_video';
     await actionManager.start(action);
 
+    // Download media — throws on transient errors for withRetry to retry
     logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
     const result = await withRetry(
       () =>
@@ -367,29 +422,14 @@ async function processMediaRequest(
       return;
     }
 
-    const mediaItems = await buildMediaItems(result.filePaths, logContext, requestId);
+    filePaths = result.filePaths;
+    mediaItems = await buildMediaItems(filePaths, logContext, requestId);
 
     if (mediaItems.length > 1) {
       await sendMediaGroup(ctx, mediaItems, result.mediaInfo, url, messageId);
     } else {
       await sendSingleMedia(ctx, mediaItems[0], result.mediaInfo, url, messageId);
     }
-
-    await Promise.all(
-      mediaItems.map(async (item) => {
-        const files = [item.path];
-        if (item.isVideo) files.push(`${item.path}.thumb.jpg`);
-        await Promise.all(
-          files.map((file) =>
-            downloader
-              .cleanup(file)
-              .catch((error) =>
-                logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-              ),
-          ),
-        );
-      }),
-    );
 
     logger.debug(`Successfully processed media request for ${userInfo}`, {
       ...logContext,
@@ -402,6 +442,7 @@ async function processMediaRequest(
       .catch(() => {});
   } finally {
     actionManager.stop();
+    await cleanupFiles(filePaths, mediaItems, downloader, logContext, requestId);
   }
 }
 
@@ -412,42 +453,49 @@ async function buildMediaItems(
 ): Promise<MediaItem[]> {
   return Promise.all(
     filePaths.map(async (path) => {
-      assertSafePath(path, env.TMP_DIR);
-      const probe = await probeMediaFile(path);
-      const isVideo = path.endsWith('.mp4');
+      return probeSemaphore.run(async () => {
+        assertSafePath(path, env.TMP_DIR);
+        const probe = await probeMediaFile(path);
 
-      let thumbnail: Buffer | null = null;
-      if (isVideo) {
-        logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
-        thumbnail = await generateThumbnail(path);
-        if (thumbnail) {
-          logger.debug('Thumbnail created successfully', {
-            ...logContext,
-            requestId,
-            size: thumbnail.length,
-          });
-        }
-      }
-
-      const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
-      const fileSize = probe.format?.size ? parseInt(probe.format.size) : 0;
-      const fileSizeMB = fileSize ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
-
-      if (fileSize > env.MAX_FILE_SIZE) {
-        throw new Error(
-          `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
+        // Determine video from probe data, not file extension
+        const isVideo = probe.streams.some(
+          (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
         );
-      }
 
-      return {
-        path,
-        isVideo,
-        thumbnail: thumbnail ?? undefined,
-        videoWidth: width,
-        videoHeight: height,
-        streamInfo: info,
-        fileSizeMB,
-      };
+        let thumbnail: Buffer | null = null;
+        if (isVideo) {
+          logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
+          thumbnail = await generateThumbnail(path);
+          if (thumbnail) {
+            logger.debug('Thumbnail created successfully', {
+              ...logContext,
+              requestId,
+              size: thumbnail.length,
+            });
+          }
+        }
+
+        const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
+        const fileSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
+        const fileSizeMB =
+          Number.isFinite(fileSize) && fileSize > 0 ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
+
+        if (Number.isFinite(fileSize) && fileSize > env.MAX_FILE_SIZE) {
+          throw new Error(
+            `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
+          );
+        }
+
+        return {
+          path,
+          isVideo,
+          thumbnail: thumbnail ?? undefined,
+          videoWidth: width,
+          videoHeight: height,
+          streamInfo: info,
+          fileSizeMB,
+        };
+      });
     }),
   );
 }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,18 +1,18 @@
 import { Context, InputFile } from 'grammy';
-import { readFile, stat, unlink } from 'fs/promises';
 import { isValidUrl, isSupportedPlatform } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
 import type { MediaMetadata } from '../services/downloader.js';
+import { probeMediaFile, generateThumbnail, extractStreamInfo } from '../services/mediaProbe.js';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
 import { RateLimiter } from '../utils/rateLimit.js';
-import { safeExec } from '../utils/exec.js';
 import { assertSafePath } from '../utils/pathSafety.js';
-import { escapeMarkdownV2, escapeMarkdownV2Url, normalizeLineBreaks } from '../utils/markdown.js';
+import { buildSingleCaption, buildGroupCaption } from '../utils/caption.js';
 import { Semaphore } from '../utils/concurrency.js';
+import { ChatActionManager } from '../utils/chatAction.js';
+import type { ChatAction } from '../utils/chatAction.js';
 
-const THUMBNAIL_MAX_BYTES = 200 * 1024;
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
@@ -22,22 +22,6 @@ const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
 const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
-type ChatAction = 'typing' | 'upload_photo' | 'upload_video' | 'upload_voice' | 'upload_document';
-
-interface FFprobeStream {
-  codec_type: string;
-  codec_name: string;
-  width?: number;
-  height?: number;
-  sample_rate?: string;
-  bit_rate?: string;
-}
-
-interface FFprobeData {
-  streams: FFprobeStream[];
-  format?: { size?: string; bit_rate?: string };
-}
-
 interface MediaItem {
   path: string;
   isVideo: boolean;
@@ -46,246 +30,6 @@ interface MediaItem {
   videoHeight?: number;
   streamInfo: string;
   fileSizeMB: string;
-}
-
-// --- Chat Action Manager ---
-
-class ChatActionManager {
-  private timer: NodeJS.Timeout | null = null;
-  private inFlight = false;
-  private stopped = false;
-
-  constructor(
-    private ctx: Context,
-    private chatId: number,
-  ) {}
-
-  async start(action: ChatAction): Promise<void> {
-    this.stop();
-    this.stopped = false;
-    try {
-      await this.sendAction(action);
-    } catch (error) {
-      logger.error('Failed to start chat action', { error });
-      return;
-    }
-    this.scheduleNext(action);
-  }
-
-  private scheduleNext(action: ChatAction): void {
-    if (this.stopped) return;
-    this.timer = setTimeout(async () => {
-      if (this.inFlight || this.stopped) return;
-      this.inFlight = true;
-      try {
-        await this.sendAction(action);
-      } catch (error) {
-        if (!(error instanceof Error) || !error.message?.includes('Network request')) {
-          logger.error('Failed to send chat action', { error });
-        }
-      } finally {
-        this.inFlight = false;
-        if (!this.stopped) this.scheduleNext(action);
-      }
-    }, 1000);
-  }
-
-  private async sendAction(action: ChatAction): Promise<void> {
-    await withRetry(() => this.ctx.api.sendChatAction(this.chatId, action), {
-      maxAttempts: 5,
-      initialDelay: 500,
-      maxDelay: 5000,
-    });
-  }
-
-  stop(): void {
-    this.stopped = true;
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
-  }
-}
-
-// --- Media Probe Helpers ---
-
-async function probeMediaFile(path: string): Promise<FFprobeData> {
-  const { stdout } = await safeExec('ffprobe', [
-    '-v',
-    'quiet',
-    '-print_format',
-    'json',
-    '-show_format',
-    '-show_streams',
-    path,
-  ]);
-  try {
-    return JSON.parse(stdout) as FFprobeData;
-  } catch {
-    throw new Error(`Failed to parse ffprobe output for ${path}`);
-  }
-}
-
-async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
-  const thumbnailPath = `${videoPath}.thumb.jpg`;
-  assertSafePath(thumbnailPath, env.TMP_DIR);
-  try {
-    await safeExec('ffmpeg', [
-      '-y',
-      '-i',
-      videoPath,
-      '-vf',
-      "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease",
-      '-q:v',
-      '6',
-      '-frames:v',
-      '1',
-      thumbnailPath,
-    ]);
-    const stats = await stat(thumbnailPath);
-    if (stats.size === 0 || stats.size > THUMBNAIL_MAX_BYTES) {
-      await unlink(thumbnailPath).catch(() => {});
-      return null;
-    }
-    return await readFile(thumbnailPath);
-  } catch {
-    return null;
-  }
-}
-
-function extractStreamInfo(
-  streams: FFprobeStream[],
-  isVideo: boolean,
-  format?: FFprobeData['format'],
-): { info: string; width?: number; height?: number } {
-  const videoStream = streams.find((s) => s.codec_type === 'video');
-  const width = videoStream?.width;
-  const height = videoStream?.height;
-
-  const parts = streams
-    .map((stream) => {
-      if (stream.codec_type === 'video') {
-        if (!isVideo) return `${stream.codec_name} ${stream.width ?? '?'}x${stream.height ?? '?'}`;
-        const bitrate = stream.bit_rate
-          ? `${Math.round(parseInt(stream.bit_rate, 10) / 1000)}kbps`
-          : format?.bit_rate
-            ? `${Math.round(parseInt(format.bit_rate, 10) / 1000)}kbps`
-            : '';
-        return `${stream.codec_name} ${stream.width ?? '?'}x${stream.height ?? '?'}${bitrate ? ` ${bitrate}` : ''}`;
-      }
-      if (stream.codec_type === 'audio') {
-        const bitrate = stream.bit_rate
-          ? `${Math.round(parseInt(stream.bit_rate, 10) / 1000)}kbps`
-          : format?.bit_rate
-            ? `${Math.round(parseInt(format.bit_rate, 10) / 1000)}kbps`
-            : '';
-        const sampleRate = stream.sample_rate
-          ? `${Math.round(parseInt(stream.sample_rate, 10) / 1000)}kHz`
-          : '';
-        return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
-      }
-      return null;
-    })
-    .filter(Boolean)
-    .join(', ');
-
-  return { info: parts, width, height };
-}
-
-// --- Caption Builders ---
-
-function buildSingleCaption(title: string, url: string, item: MediaItem): string {
-  const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
-  const escapedUrl = escapeMarkdownV2Url(url);
-  const escapedInfo = escapeMarkdownV2(item.streamInfo);
-  const escapedSize = escapeMarkdownV2(item.fileSizeMB);
-  return `[${escapedTitle}](${escapedUrl})\n\`${escapedInfo}, ${escapedSize}MB\``;
-}
-
-function buildGroupCaption(
-  title: string,
-  url: string,
-  chunk: MediaItem[],
-  isFirstChunk: boolean,
-): string {
-  const imageFormats = new Map<string, { count: number; codec: string; dims: string }>();
-  const videoFormats = new Map<string, { count: number; codec: string; dims: string }>();
-  let chunkTotalSize = 0;
-
-  for (const item of chunk) {
-    const parts = item.streamInfo.split(' ');
-    const codec = parts[0] || 'unknown';
-    const dims = parts[1] || 'unknown';
-    const key = `${codec}-${dims}`;
-
-    if (item.isVideo) {
-      const existing = videoFormats.get(key) || { count: 0, codec, dims };
-      videoFormats.set(key, { ...existing, count: existing.count + 1 });
-    } else {
-      const existing = imageFormats.get(key) || { count: 0, codec, dims };
-      imageFormats.set(key, { ...existing, count: existing.count + 1 });
-    }
-    chunkTotalSize += parseFloat(item.fileSizeMB);
-  }
-
-  const formatParts: string[] = [];
-  if (imageFormats.size > 0) {
-    const summary = Array.from(imageFormats.values())
-      .map((i) => `${i.count} ${i.codec} image${i.count > 1 ? 's' : ''} at ${i.dims}`)
-      .join(', ');
-    formatParts.push(summary);
-  }
-  if (videoFormats.size > 0) {
-    const summary = Array.from(videoFormats.values())
-      .map((i) => `${i.count} ${i.codec} video${i.count > 1 ? 's' : ''} at ${i.dims}`)
-      .join(', ');
-    formatParts.push(summary);
-  }
-
-  const escapedSummary = escapeMarkdownV2(formatParts.join(', '));
-  const escapedSize = escapeMarkdownV2(chunkTotalSize.toFixed(1));
-  const sizeLabel = `\`${escapedSummary}, ${escapedSize}MB total\``;
-
-  if (isFirstChunk) {
-    const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
-    const escapedUrl = escapeMarkdownV2Url(url);
-    return `[${escapedTitle}](${escapedUrl})\n${sizeLabel}`;
-  }
-  return sizeLabel;
-}
-
-// --- Cleanup Helper ---
-
-async function cleanupFiles(
-  filePaths: string[],
-  mediaItems: MediaItem[],
-  downloader: MediaDownloader,
-  logContext: Record<string, unknown>,
-  requestId: string,
-): Promise<void> {
-  const pathsToClean = new Set<string>();
-
-  // Add raw download paths (covers case where buildMediaItems fails)
-  for (const p of filePaths) {
-    pathsToClean.add(p);
-    pathsToClean.add(`${p}.thumb.jpg`);
-  }
-
-  // Add media item paths (may include thumbnails)
-  for (const item of mediaItems) {
-    pathsToClean.add(item.path);
-    if (item.isVideo) pathsToClean.add(`${item.path}.thumb.jpg`);
-  }
-
-  await Promise.all(
-    Array.from(pathsToClean).map((file) =>
-      downloader
-        .cleanup(file)
-        .catch((error) =>
-          logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-        ),
-    ),
-  );
 }
 
 // --- Main Handler ---
@@ -334,6 +78,7 @@ export async function handleMessage(ctx: Context): Promise<void> {
       }
     }
 
+    // Process only the first URL per message
     const url = urls[0];
     logger.info(`${userInfo} requested: ${url}`, { ...logContext, requestId });
 
@@ -345,6 +90,8 @@ export async function handleMessage(ctx: Context): Promise<void> {
     await ctx.reply('Failed to process message').catch(() => {});
   }
 }
+
+// --- Request Processing ---
 
 async function processMediaRequest(
   ctx: Context,
@@ -361,53 +108,22 @@ async function processMediaRequest(
   let mediaItems: MediaItem[] = [];
 
   try {
-    await actionManager.start('typing');
-
-    // Get media info — throws on failure for withRetry to retry
-    logger.info('Fetching media info...', { ...logContext, requestId });
-    let mediaInfo: MediaMetadata;
-    try {
-      mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
-        maxAttempts: 5,
-        initialDelay: 2000,
-        maxDelay: 15000,
-      });
-    } catch (error) {
-      logger.warn('Failed to get media information after retries', {
-        ...logContext,
-        requestId,
-        error,
-      });
+    const mediaInfo = await fetchMediaInfo(downloader, url, actionManager, logContext, requestId);
+    if (!mediaInfo) {
       await ctx.reply('Failed to get media information after several attempts', {
         reply_to_message_id: messageId,
       });
       return;
     }
 
-    const action: ChatAction =
-      mediaInfo.format === 'audio'
-        ? 'upload_voice'
-        : mediaInfo.format === 'image'
-          ? 'upload_photo'
-          : 'upload_video';
-    await actionManager.start(action);
-
-    // Download media — throws on transient errors for withRetry to retry
-    logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
-    const result = await withRetry(
-      () =>
-        downloader.download(
-          url,
-          {
-            maxFileSize: env.MAX_FILE_SIZE,
-            timeout: env.DOWNLOAD_TIMEOUT,
-            format: mediaInfo.format,
-          },
-          mediaInfo,
-        ),
-      { maxAttempts: 3, initialDelay: 3000, maxDelay: 20000 },
+    const result = await downloadMedia(
+      downloader,
+      url,
+      mediaInfo,
+      actionManager,
+      logContext,
+      requestId,
     );
-
     actionManager.stop();
 
     if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
@@ -446,18 +162,72 @@ async function processMediaRequest(
   }
 }
 
+async function fetchMediaInfo(
+  downloader: MediaDownloader,
+  url: string,
+  actionManager: ChatActionManager,
+  logContext: Record<string, unknown>,
+  requestId: string,
+): Promise<MediaMetadata | null> {
+  await actionManager.start('typing');
+  logger.info('Fetching media info...', { ...logContext, requestId });
+  try {
+    return await withRetry(() => downloader.getMediaInfo(url), {
+      maxAttempts: 5,
+      initialDelay: 2000,
+      maxDelay: 15000,
+    });
+  } catch (error) {
+    logger.warn('Failed to get media information after retries', {
+      ...logContext,
+      requestId,
+      error,
+    });
+    return null;
+  }
+}
+
+async function downloadMedia(
+  downloader: MediaDownloader,
+  url: string,
+  mediaInfo: MediaMetadata,
+  actionManager: ChatActionManager,
+  logContext: Record<string, unknown>,
+  requestId: string,
+): ReturnType<MediaDownloader['download']> {
+  const action: ChatAction =
+    mediaInfo.format === 'audio'
+      ? 'upload_voice'
+      : mediaInfo.format === 'image'
+        ? 'upload_photo'
+        : 'upload_video';
+  await actionManager.start(action);
+
+  logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
+  return withRetry(
+    () =>
+      downloader.download(
+        url,
+        { maxFileSize: env.MAX_FILE_SIZE, timeout: env.DOWNLOAD_TIMEOUT, format: mediaInfo.format },
+        mediaInfo,
+      ),
+    { maxAttempts: 3, initialDelay: 3000, maxDelay: 20000 },
+  );
+}
+
+// --- Media Item Building ---
+
 async function buildMediaItems(
   filePaths: string[],
   logContext: Record<string, unknown>,
   requestId: string,
 ): Promise<MediaItem[]> {
   return Promise.all(
-    filePaths.map(async (path) => {
-      return probeSemaphore.run(async () => {
+    filePaths.map((path) =>
+      probeSemaphore.run(async () => {
         assertSafePath(path, env.TMP_DIR);
         const probe = await probeMediaFile(path);
 
-        // Determine video from probe data, not file extension
         const isVideo = probe.streams.some(
           (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
         );
@@ -467,11 +237,7 @@ async function buildMediaItems(
           logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
           thumbnail = await generateThumbnail(path);
           if (thumbnail) {
-            logger.debug('Thumbnail created successfully', {
-              ...logContext,
-              requestId,
-              size: thumbnail.length,
-            });
+            logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
           }
         }
 
@@ -495,10 +261,12 @@ async function buildMediaItems(
           streamInfo: info,
           fileSizeMB,
         };
-      });
-    }),
+      }),
+    ),
   );
 }
+
+// --- Telegram Send ---
 
 async function sendMediaGroup(
   ctx: Context,
@@ -513,7 +281,6 @@ async function sendMediaGroup(
 
     const mediaGroup = chunk.map((item, index) => {
       const captionOpts = index === 0 ? { caption, parse_mode: 'MarkdownV2' as const } : {};
-
       if (item.isVideo) {
         return {
           type: 'video' as const,
@@ -557,4 +324,37 @@ async function sendSingleMedia(
   } else {
     await ctx.replyWithPhoto(new InputFile(item.path), baseOpts);
   }
+}
+
+// --- Cleanup ---
+
+async function cleanupFiles(
+  filePaths: string[],
+  mediaItems: MediaItem[],
+  downloader: MediaDownloader,
+  logContext: Record<string, unknown>,
+  requestId: string,
+): Promise<void> {
+  const pathsToClean = new Set<string>();
+
+  // Raw download paths (covers case where buildMediaItems fails before producing items)
+  for (const p of filePaths) {
+    pathsToClean.add(p);
+  }
+
+  // Media item paths + video thumbnails
+  for (const item of mediaItems) {
+    pathsToClean.add(item.path);
+    if (item.isVideo) pathsToClean.add(`${item.path}.thumb.jpg`);
+  }
+
+  await Promise.all(
+    Array.from(pathsToClean).map((file) =>
+      downloader
+        .cleanup(file)
+        .catch((error) =>
+          logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
+        ),
+    ),
+  );
 }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -17,10 +17,27 @@ const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
 const MAX_CONCURRENT_PROBES = 10;
+const MEDIA_INFO_CACHE_TTL = 5 * 60 * 1000;
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
 const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
 const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
+
+// Simple TTL cache for media info to avoid re-fetching the same URL
+const mediaInfoCache = new Map<string, { data: MediaMetadata; expiry: number }>();
+
+function getCachedMediaInfo(url: string): MediaMetadata | null {
+  const cached = mediaInfoCache.get(url);
+  if (!cached || Date.now() > cached.expiry) {
+    mediaInfoCache.delete(url);
+    return null;
+  }
+  return cached.data;
+}
+
+function cacheMediaInfo(url: string, data: MediaMetadata): void {
+  mediaInfoCache.set(url, { data, expiry: Date.now() + MEDIA_INFO_CACHE_TTL });
+}
 
 interface MediaItem {
   path: string;
@@ -43,48 +60,39 @@ export async function handleMessage(ctx: Context): Promise<void> {
   const chatType = ctx.chat?.type;
   const isAnonymousAdmin = ctx.from?.username === 'GroupAnonymousBot';
 
-  const logContext = {
-    type: chatType,
-    chat: chatId,
-    from: isAnonymousAdmin ? 'AnonymousAdmin' : username || userId,
-    msgId: messageId,
-  };
+  const logCtx = { type: chatType, chat: chatId, msgId: messageId };
   const userInfo = isAnonymousAdmin
     ? 'Anonymous Admin'
     : username
       ? `@${username}`
       : `user ${userId}`;
-  const requestId = `[${chatId}:${messageId}]`;
 
   if (!messageText || !chatId || !messageId) {
-    logger.warn('Skipping message due to missing text, chatId, or messageId', logContext);
+    logger.warn('Skipping: missing text, chatId, or messageId', logCtx);
     return;
   }
 
   try {
-    // Extract URLs first — only consume rate limit if there's a supported URL
     const urls = messageText.split(/\s+/).filter(isSupportedUrl);
     if (urls.length === 0) return;
 
-    // Rate limit: use chatId as fallback for anonymous admins
     const rateLimitKey = userId && !isAnonymousAdmin ? userId : chatId;
     if (!RateLimiter.getInstance().tryConsume(rateLimitKey)) {
-      logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
+      logger.info(`Rate limited ${userInfo}`, logCtx);
       await ctx.reply('You are sending requests too quickly. Please try again later.', {
         reply_to_message_id: messageId,
       });
       return;
     }
 
-    // Process only the first URL per message
     const url = urls[0];
-    logger.info(`${userInfo} requested: ${url}`, { ...logContext, requestId });
+    logger.info(`${userInfo} → ${url}`, logCtx);
 
     await downloadSemaphore.run(() =>
-      processMediaRequest(ctx, url, chatId, messageId, logContext, requestId, userInfo),
+      processMediaRequest(ctx, url, chatId, messageId, logCtx, userInfo),
     );
   } catch (error) {
-    logger.error('Failed to process message', { error });
+    logger.error('Failed to process message', { ...logCtx, error });
     await ctx.reply('Failed to process message').catch(() => {});
   }
 }
@@ -96,8 +104,7 @@ async function processMediaRequest(
   url: string,
   chatId: number,
   messageId: number,
-  logContext: Record<string, unknown>,
-  requestId: string,
+  logCtx: Record<string, unknown>,
   userInfo: string,
 ): Promise<void> {
   const downloader = MediaDownloader.getInstance();
@@ -106,7 +113,7 @@ async function processMediaRequest(
   let mediaItems: MediaItem[] = [];
 
   try {
-    const mediaInfo = await fetchMediaInfo(downloader, url, actionManager, logContext, requestId);
+    const mediaInfo = await fetchMediaInfo(downloader, url, actionManager, logCtx);
     if (!mediaInfo) {
       await ctx.reply('Failed to get media information after several attempts', {
         reply_to_message_id: messageId,
@@ -114,22 +121,11 @@ async function processMediaRequest(
       return;
     }
 
-    const result = await downloadMedia(
-      downloader,
-      url,
-      mediaInfo,
-      actionManager,
-      logContext,
-      requestId,
-    );
+    const result = await downloadMedia(downloader, url, mediaInfo, actionManager, logCtx);
     actionManager.stop();
 
     if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
-      logger.error('Failed to process media after retries', {
-        ...logContext,
-        requestId,
-        error: result.error,
-      });
+      logger.error('Download failed', { ...logCtx, error: result.error });
       await ctx.reply('Failed to process media. Please try a different URL.', {
         reply_to_message_id: messageId,
       });
@@ -137,7 +133,7 @@ async function processMediaRequest(
     }
 
     filePaths = result.filePaths;
-    mediaItems = await buildMediaItems(filePaths, logContext, requestId);
+    mediaItems = await buildMediaItems(filePaths, logCtx);
 
     if (mediaItems.length > 1) {
       await sendMediaGroup(ctx, mediaItems, result.mediaInfo, url, messageId);
@@ -145,18 +141,15 @@ async function processMediaRequest(
       await sendSingleMedia(ctx, mediaItems[0], result.mediaInfo, url, messageId);
     }
 
-    logger.debug(`Successfully processed media request for ${userInfo}`, {
-      ...logContext,
-      requestId,
-    });
+    logger.debug(`Done for ${userInfo}`, logCtx);
   } catch (error) {
-    logger.error('Failed to process media request', { error });
+    logger.error('Failed to process media request', { ...logCtx, error });
     await ctx
       .reply('Failed to process media request', { reply_to_message_id: messageId })
       .catch(() => {});
   } finally {
     actionManager.stop();
-    await cleanupFiles(filePaths, mediaItems, downloader, logContext, requestId);
+    await cleanupFiles(filePaths, mediaItems, downloader, logCtx);
   }
 }
 
@@ -164,23 +157,27 @@ async function fetchMediaInfo(
   downloader: MediaDownloader,
   url: string,
   actionManager: ChatActionManager,
-  logContext: Record<string, unknown>,
-  requestId: string,
+  logCtx: Record<string, unknown>,
 ): Promise<MediaMetadata | null> {
+  // Check cache first
+  const cached = getCachedMediaInfo(url);
+  if (cached) {
+    logger.info(`Media info cache hit`, logCtx);
+    return cached;
+  }
+
   await actionManager.start('typing');
-  logger.info('Fetching media info...', { ...logContext, requestId });
+  logger.info('Fetching media info...', logCtx);
   try {
-    return await withRetry(() => downloader.getMediaInfo(url), {
+    const info = await withRetry(() => downloader.getMediaInfo(url), {
       maxAttempts: 5,
       initialDelay: 2000,
       maxDelay: 15000,
     });
+    cacheMediaInfo(url, info);
+    return info;
   } catch (error) {
-    logger.warn('Failed to get media information after retries', {
-      ...logContext,
-      requestId,
-      error,
-    });
+    logger.warn('Failed to get media info', { ...logCtx, error });
     return null;
   }
 }
@@ -190,8 +187,7 @@ async function downloadMedia(
   url: string,
   mediaInfo: MediaMetadata,
   actionManager: ChatActionManager,
-  logContext: Record<string, unknown>,
-  requestId: string,
+  logCtx: Record<string, unknown>,
 ): ReturnType<MediaDownloader['download']> {
   const action: ChatAction =
     mediaInfo.format === 'audio'
@@ -201,7 +197,7 @@ async function downloadMedia(
         : 'upload_video';
   await actionManager.start(action);
 
-  logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
+  logger.info(`Downloading ${mediaInfo.format}`, logCtx);
   return withRetry(
     () =>
       downloader.download(
@@ -217,11 +213,8 @@ async function downloadMedia(
 
 async function buildMediaItems(
   filePaths: string[],
-  logContext: Record<string, unknown>,
-  requestId: string,
+  logCtx: Record<string, unknown>,
 ): Promise<MediaItem[]> {
-  // Use allSettled + semaphore so all probes complete before cleanup,
-  // and concurrent ffprobe/ffmpeg processes are bounded
   const results = await Promise.allSettled(
     filePaths.map((path) =>
       probeSemaphore.run(async () => {
@@ -234,11 +227,8 @@ async function buildMediaItems(
 
         let thumbnail: Buffer | null = null;
         if (isVideo) {
-          logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
+          logger.debug('Creating thumbnail', { ...logCtx, path });
           thumbnail = await generateThumbnail(path);
-          if (thumbnail) {
-            logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
-          }
         }
 
         const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
@@ -265,7 +255,6 @@ async function buildMediaItems(
     ),
   );
 
-  // If any probe failed, throw the first error (after all have settled)
   const rejected = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
   if (rejected) throw rejected.reason;
 
@@ -338,17 +327,14 @@ async function cleanupFiles(
   filePaths: string[],
   mediaItems: MediaItem[],
   downloader: MediaDownloader,
-  logContext: Record<string, unknown>,
-  requestId: string,
+  logCtx: Record<string, unknown>,
 ): Promise<void> {
   const pathsToClean = new Set<string>();
 
-  // Raw download paths (covers buildMediaItems failure case)
   for (const p of filePaths) {
     pathsToClean.add(p);
   }
 
-  // Media item paths (thumbnails already deleted by generateThumbnail)
   for (const item of mediaItems) {
     pathsToClean.add(item.path);
   }
@@ -357,9 +343,7 @@ async function cleanupFiles(
     Array.from(pathsToClean).map((file) =>
       downloader
         .cleanup(file)
-        .catch((error) =>
-          logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-        ),
+        .catch((error) => logger.warn('Cleanup failed', { ...logCtx, file, error })),
     ),
   );
 }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,4 +1,5 @@
 import { Context, InputFile } from 'grammy';
+import { existsSync } from 'fs';
 import { isSupportedUrl } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
 import type { MediaMetadata } from '../services/downloader.js';
@@ -12,32 +13,19 @@ import { buildSingleCaption, buildGroupCaption } from '../utils/caption.js';
 import { Semaphore } from '../utils/concurrency.js';
 import { ChatActionManager } from '../utils/chatAction.js';
 import type { ChatAction } from '../utils/chatAction.js';
+import { normalizeUrl } from '../utils/urlNormalize.js';
 
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
 const MAX_CONCURRENT_PROBES = 10;
-const MEDIA_INFO_CACHE_TTL = 5 * 60 * 1000;
+const DOWNLOAD_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
 const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
 const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
-// Simple TTL cache for media info to avoid re-fetching the same URL
-const mediaInfoCache = new Map<string, { data: MediaMetadata; expiry: number }>();
-
-function getCachedMediaInfo(url: string): MediaMetadata | null {
-  const cached = mediaInfoCache.get(url);
-  if (!cached || Date.now() > cached.expiry) {
-    mediaInfoCache.delete(url);
-    return null;
-  }
-  return cached.data;
-}
-
-function cacheMediaInfo(url: string, data: MediaMetadata): void {
-  mediaInfoCache.set(url, { data, expiry: Date.now() + MEDIA_INFO_CACHE_TTL });
-}
+// --- Download Cache ---
 
 interface MediaItem {
   path: string;
@@ -47,6 +35,55 @@ interface MediaItem {
   videoHeight?: number;
   streamInfo: string;
   fileSizeMB: string;
+}
+
+interface CachedDownload {
+  mediaInfo: MediaMetadata;
+  mediaItems: MediaItem[];
+  expiry: number;
+}
+
+const downloadCache = new Map<string, CachedDownload>();
+
+// Evict expired entries and clean up their files
+const cacheEvictTimer = setInterval(
+  () => {
+    const now = Date.now();
+    const downloader = MediaDownloader.getInstance();
+    for (const [key, entry] of downloadCache) {
+      if (now > entry.expiry) {
+        downloadCache.delete(key);
+        for (const item of entry.mediaItems) {
+          downloader.cleanup(item.path).catch(() => {});
+        }
+      }
+    }
+  },
+  5 * 60 * 1000,
+);
+cacheEvictTimer.unref();
+
+function getCachedDownload(url: string): CachedDownload | null {
+  const key = normalizeUrl(url);
+  const cached = downloadCache.get(key);
+  if (!cached || Date.now() > cached.expiry) {
+    if (cached) downloadCache.delete(key);
+    return null;
+  }
+  // Verify files still exist on disk
+  if (cached.mediaItems.every((item) => existsSync(item.path))) {
+    return cached;
+  }
+  downloadCache.delete(key);
+  return null;
+}
+
+function cacheDownload(url: string, mediaInfo: MediaMetadata, mediaItems: MediaItem[]): void {
+  downloadCache.set(normalizeUrl(url), {
+    mediaInfo,
+    mediaItems,
+    expiry: Date.now() + DOWNLOAD_CACHE_TTL,
+  });
 }
 
 // --- Main Handler ---
@@ -73,7 +110,12 @@ export async function handleMessage(ctx: Context): Promise<void> {
   }
 
   try {
-    const urls = messageText.split(/\s+/).filter(isSupportedUrl);
+    // Detect +info flag at end of message
+    const trimmed = messageText.trim();
+    const showInfo = trimmed.endsWith('+info');
+    const textForParsing = showInfo ? trimmed.slice(0, -5).trim() : trimmed;
+
+    const urls = textForParsing.split(/\s+/).filter(isSupportedUrl);
     if (urls.length === 0) return;
 
     const rateLimitKey = userId && !isAnonymousAdmin ? userId : chatId;
@@ -86,10 +128,10 @@ export async function handleMessage(ctx: Context): Promise<void> {
     }
 
     const url = urls[0];
-    logger.info(`${userInfo} → ${url}`, logCtx);
+    logger.info(`${userInfo} → ${url}${showInfo ? ' +info' : ''}`, logCtx);
 
     await downloadSemaphore.run(() =>
-      processMediaRequest(ctx, url, chatId, messageId, logCtx, userInfo),
+      processMediaRequest(ctx, url, chatId, messageId, logCtx, showInfo),
     );
   } catch (error) {
     logger.error('Failed to process message', { ...logCtx, error });
@@ -105,12 +147,25 @@ async function processMediaRequest(
   chatId: number,
   messageId: number,
   logCtx: Record<string, unknown>,
-  userInfo: string,
+  showInfo: boolean,
 ): Promise<void> {
+  // Check download cache first
+  const cached = getCachedDownload(url);
+  if (cached) {
+    logger.info('Cache hit — re-sending', logCtx);
+    if (cached.mediaItems.length > 1) {
+      await sendMediaGroup(ctx, cached.mediaItems, cached.mediaInfo, url, messageId, showInfo);
+    } else {
+      await sendSingleMedia(ctx, cached.mediaItems[0], cached.mediaInfo, url, messageId, showInfo);
+    }
+    return;
+  }
+
   const downloader = MediaDownloader.getInstance();
   const actionManager = new ChatActionManager(ctx, chatId);
   let filePaths: string[] = [];
   let mediaItems: MediaItem[] = [];
+  let cacheResult = false;
 
   try {
     const mediaInfo = await fetchMediaInfo(downloader, url, actionManager, logCtx);
@@ -136,12 +191,15 @@ async function processMediaRequest(
     mediaItems = await buildMediaItems(filePaths, logCtx);
 
     if (mediaItems.length > 1) {
-      await sendMediaGroup(ctx, mediaItems, result.mediaInfo, url, messageId);
+      await sendMediaGroup(ctx, mediaItems, result.mediaInfo, url, messageId, showInfo);
     } else {
-      await sendSingleMedia(ctx, mediaItems[0], result.mediaInfo, url, messageId);
+      await sendSingleMedia(ctx, mediaItems[0], result.mediaInfo, url, messageId, showInfo);
     }
 
-    logger.debug(`Done for ${userInfo}`, logCtx);
+    // Cache on success — files stay on disk until cache expires
+    cacheDownload(url, result.mediaInfo, mediaItems);
+    cacheResult = true;
+    logger.debug('Cached download result', logCtx);
   } catch (error) {
     logger.error('Failed to process media request', { ...logCtx, error });
     await ctx
@@ -149,7 +207,10 @@ async function processMediaRequest(
       .catch(() => {});
   } finally {
     actionManager.stop();
-    await cleanupFiles(filePaths, mediaItems, downloader, logCtx);
+    // Only clean up if NOT cached (cached files expire via eviction timer)
+    if (!cacheResult) {
+      await cleanupFiles(filePaths, mediaItems, downloader, logCtx);
+    }
   }
 }
 
@@ -159,23 +220,14 @@ async function fetchMediaInfo(
   actionManager: ChatActionManager,
   logCtx: Record<string, unknown>,
 ): Promise<MediaMetadata | null> {
-  // Check cache first
-  const cached = getCachedMediaInfo(url);
-  if (cached) {
-    logger.info(`Media info cache hit`, logCtx);
-    return cached;
-  }
-
   await actionManager.start('typing');
   logger.info('Fetching media info...', logCtx);
   try {
-    const info = await withRetry(() => downloader.getMediaInfo(url), {
+    return await withRetry(() => downloader.getMediaInfo(url), {
       maxAttempts: 5,
       initialDelay: 2000,
       maxDelay: 15000,
     });
-    cacheMediaInfo(url, info);
-    return info;
   } catch (error) {
     logger.warn('Failed to get media info', { ...logCtx, error });
     return null;
@@ -269,13 +321,15 @@ async function sendMediaGroup(
   mediaInfo: { title: string },
   url: string,
   messageId: number,
+  showInfo: boolean,
 ): Promise<void> {
   for (let i = 0; i < mediaItems.length; i += MAX_MEDIA_GROUP_SIZE) {
     const chunk = mediaItems.slice(i, i + MAX_MEDIA_GROUP_SIZE);
-    const caption = buildGroupCaption(mediaInfo.title, url, chunk, i === 0);
+    const caption = showInfo ? buildGroupCaption(mediaInfo.title, url, chunk, i === 0) : undefined;
 
     const mediaGroup = chunk.map((item, index) => {
-      const captionOpts = index === 0 ? { caption, parse_mode: 'MarkdownV2' as const } : {};
+      const captionOpts =
+        index === 0 && caption ? { caption, parse_mode: 'MarkdownV2' as const } : {};
       if (item.isVideo) {
         return {
           type: 'video' as const,
@@ -303,9 +357,13 @@ async function sendSingleMedia(
   mediaInfo: { title: string; format: string },
   url: string,
   messageId: number,
+  showInfo: boolean,
 ): Promise<void> {
-  const caption = buildSingleCaption(mediaInfo.title, url, item);
-  const baseOpts = { caption, reply_to_message_id: messageId, parse_mode: 'MarkdownV2' as const };
+  const caption = showInfo ? buildSingleCaption(mediaInfo.title, url, item) : undefined;
+  const baseOpts = {
+    reply_to_message_id: messageId,
+    ...(caption && { caption, parse_mode: 'MarkdownV2' as const }),
+  };
 
   if (mediaInfo.format === 'audio') {
     await ctx.replyWithVoice(new InputFile(item.path), baseOpts);
@@ -334,7 +392,6 @@ async function cleanupFiles(
   for (const p of filePaths) {
     pathsToClean.add(p);
   }
-
   for (const item of mediaItems) {
     pathsToClean.add(item.path);
   }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,5 +1,5 @@
 import { Context, InputFile } from 'grammy';
-import { isValidUrl, isSupportedPlatform } from '../utils/url.js';
+import { isSupportedUrl } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
 import type { MediaMetadata } from '../services/downloader.js';
 import { probeMediaFile, generateThumbnail, extractStreamInfo } from '../services/mediaProbe.js';
@@ -16,9 +16,7 @@ import type { ChatAction } from '../utils/chatAction.js';
 const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
-const MAX_CONCURRENT_PROBES = 10;
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
-const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
 const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
@@ -63,19 +61,17 @@ export async function handleMessage(ctx: Context): Promise<void> {
 
   try {
     // Extract URLs first — only consume rate limit if there's a supported URL
-    const words = messageText.split(/\s+/);
-    const urls = words.filter((word) => isValidUrl(word) && isSupportedPlatform(word));
+    const urls = messageText.split(/\s+/).filter(isSupportedUrl);
     if (urls.length === 0) return;
 
-    // Rate limit check AFTER URL extraction (non-URL messages don't count)
-    if (userId && !isAnonymousAdmin) {
-      if (!RateLimiter.getInstance().tryConsume(userId)) {
-        logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
-        await ctx.reply('You are sending requests too quickly. Please try again later.', {
-          reply_to_message_id: messageId,
-        });
-        return;
-      }
+    // Rate limit: use chatId as fallback for anonymous admins
+    const rateLimitKey = userId && !isAnonymousAdmin ? userId : chatId;
+    if (!RateLimiter.getInstance().tryConsume(rateLimitKey)) {
+      logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
+      await ctx.reply('You are sending requests too quickly. Please try again later.', {
+        reply_to_message_id: messageId,
+      });
+      return;
     }
 
     // Process only the first URL per message
@@ -223,46 +219,44 @@ async function buildMediaItems(
   requestId: string,
 ): Promise<MediaItem[]> {
   return Promise.all(
-    filePaths.map((path) =>
-      probeSemaphore.run(async () => {
-        assertSafePath(path, env.TMP_DIR);
-        const probe = await probeMediaFile(path);
+    filePaths.map(async (path) => {
+      assertSafePath(path, env.TMP_DIR);
+      const probe = await probeMediaFile(path);
 
-        const isVideo = probe.streams.some(
-          (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
+      const isVideo = probe.streams.some(
+        (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
+      );
+
+      let thumbnail: Buffer | null = null;
+      if (isVideo) {
+        logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
+        thumbnail = await generateThumbnail(path);
+        if (thumbnail) {
+          logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
+        }
+      }
+
+      const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
+      const fileSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
+      const fileSizeMB =
+        Number.isFinite(fileSize) && fileSize > 0 ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
+
+      if (Number.isFinite(fileSize) && fileSize > env.MAX_FILE_SIZE) {
+        throw new Error(
+          `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
         );
+      }
 
-        let thumbnail: Buffer | null = null;
-        if (isVideo) {
-          logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
-          thumbnail = await generateThumbnail(path);
-          if (thumbnail) {
-            logger.debug('Thumbnail created', { ...logContext, requestId, size: thumbnail.length });
-          }
-        }
-
-        const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
-        const fileSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
-        const fileSizeMB =
-          Number.isFinite(fileSize) && fileSize > 0 ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
-
-        if (Number.isFinite(fileSize) && fileSize > env.MAX_FILE_SIZE) {
-          throw new Error(
-            `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
-          );
-        }
-
-        return {
-          path,
-          isVideo,
-          thumbnail: thumbnail ?? undefined,
-          videoWidth: width,
-          videoHeight: height,
-          streamInfo: info,
-          fileSizeMB,
-        };
-      }),
-    ),
+      return {
+        path,
+        isVideo,
+        thumbnail: thumbnail ?? undefined,
+        videoWidth: width,
+        videoHeight: height,
+        streamInfo: info,
+        fileSizeMB,
+      };
+    }),
   );
 }
 
@@ -337,15 +331,14 @@ async function cleanupFiles(
 ): Promise<void> {
   const pathsToClean = new Set<string>();
 
-  // Raw download paths (covers case where buildMediaItems fails before producing items)
+  // Raw download paths (covers buildMediaItems failure case)
   for (const p of filePaths) {
     pathsToClean.add(p);
   }
 
-  // Media item paths + video thumbnails
+  // Media item paths (thumbnails already deleted by generateThumbnail)
   for (const item of mediaItems) {
     pathsToClean.add(item.path);
-    if (item.isVideo) pathsToClean.add(`${item.path}.thumb.jpg`);
   }
 
   await Promise.all(

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -19,7 +19,7 @@ const BYTES_PER_MB = 1024 * 1024;
 const MAX_MEDIA_GROUP_SIZE = 10;
 const MAX_CONCURRENT_DOWNLOADS = 5;
 const MAX_CONCURRENT_PROBES = 10;
-const DOWNLOAD_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+const DOWNLOAD_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
 const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,29 +1,23 @@
 import { Context, InputFile } from 'grammy';
+import { readFile, stat } from 'fs/promises';
 import { isValidUrl, isSupportedPlatform } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
 import { env } from '../config/env.js';
-import { createReadStream, stat } from 'fs';
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
 import { RateLimiter } from '../utils/rateLimit.js';
+import { safeExec } from '../utils/exec.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import { escapeMarkdownV2, normalizeLineBreaks } from '../utils/markdown.js';
+import { Semaphore } from '../utils/concurrency.js';
 
-const execAsync = promisify(exec);
-const statAsync = promisify(stat);
+const THUMBNAIL_MAX_BYTES = 200 * 1024;
+const BYTES_PER_MB = 1024 * 1024;
+const MAX_MEDIA_GROUP_SIZE = 10;
+const MAX_CONCURRENT_DOWNLOADS = 5;
+const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
 
-type ChatAction =
-  | 'typing'
-  | 'upload_photo'
-  | 'record_video'
-  | 'upload_video'
-  | 'record_voice'
-  | 'upload_voice'
-  | 'upload_document'
-  | 'choose_sticker'
-  | 'find_location'
-  | 'record_video_note'
-  | 'upload_video_note';
+type ChatAction = 'typing' | 'upload_photo' | 'upload_video' | 'upload_voice' | 'upload_document';
 
 interface FFprobeStream {
   codec_type: string;
@@ -36,17 +30,24 @@ interface FFprobeStream {
 
 interface FFprobeData {
   streams: FFprobeStream[];
-  format?: {
-    size?: string;
-    bit_rate?: string;
-  };
+  format?: { size?: string; bit_rate?: string };
 }
 
-/**
- * Manages a chat action status with immediate start and cleanup
- */
+interface MediaItem {
+  path: string;
+  isVideo: boolean;
+  thumbnail?: Buffer;
+  videoWidth?: number;
+  videoHeight?: number;
+  streamInfo: string;
+  fileSizeMB: string;
+}
+
+// --- Chat Action Manager ---
+
 class ChatActionManager {
-  private interval: NodeJS.Timeout | null = null;
+  private timer: NodeJS.Timeout | null = null;
+  private inFlight = false;
 
   constructor(
     private ctx: Context,
@@ -54,29 +55,34 @@ class ChatActionManager {
   ) {}
 
   async start(action: ChatAction): Promise<void> {
+    this.stop();
     try {
-      // Clear any existing interval
-      this.stop();
-
-      // Send action immediately with retry
-      await this.sendActionWithRetry(action);
-
-      // Set up interval for keeping the action alive
-      this.interval = setInterval(() => {
-        this.sendActionWithRetry(action).catch((error) => {
-          // Only log if it's not a network error (since those will be retried)
-          if (!error.message?.includes('Network request')) {
-            logger.error('Failed to send chat action after retries', error);
-          }
-        });
-      }, 1000);
+      await this.sendAction(action);
     } catch (error) {
-      logger.error('Failed to start chat action after retries', error);
-      this.stop();
+      logger.error('Failed to start chat action', { error });
+      return;
     }
+    this.scheduleNext(action);
   }
 
-  private async sendActionWithRetry(action: ChatAction): Promise<void> {
+  private scheduleNext(action: ChatAction): void {
+    this.timer = setTimeout(async () => {
+      if (this.inFlight) return;
+      this.inFlight = true;
+      try {
+        await this.sendAction(action);
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message?.includes('Network request')) {
+          logger.error('Failed to send chat action', { error });
+        }
+      } finally {
+        this.inFlight = false;
+        if (this.timer !== null) this.scheduleNext(action);
+      }
+    }, 1000);
+  }
+
+  private async sendAction(action: ChatAction): Promise<void> {
     await withRetry(() => this.ctx.api.sendChatAction(this.chatId, action), {
       maxAttempts: 5,
       initialDelay: 500,
@@ -85,12 +91,160 @@ class ChatActionManager {
   }
 
   stop(): void {
-    if (this.interval) {
-      clearInterval(this.interval);
-      this.interval = null;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
     }
   }
 }
+
+// --- Media Probe Helpers ---
+
+async function probeMediaFile(path: string): Promise<FFprobeData> {
+  const { stdout } = await safeExec('ffprobe', [
+    '-v',
+    'quiet',
+    '-print_format',
+    'json',
+    '-show_format',
+    '-show_streams',
+    path,
+  ]);
+  try {
+    return JSON.parse(stdout) as FFprobeData;
+  } catch {
+    throw new Error(`Failed to parse ffprobe output for ${path}`);
+  }
+}
+
+async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
+  const thumbnailPath = `${videoPath}.thumb.jpg`;
+  try {
+    await safeExec('ffmpeg', [
+      '-y',
+      '-i',
+      videoPath,
+      '-vf',
+      "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease",
+      '-q:v',
+      '6',
+      '-frames:v',
+      '1',
+      thumbnailPath,
+    ]);
+    const stats = await stat(thumbnailPath);
+    if (stats.size === 0 || stats.size > THUMBNAIL_MAX_BYTES) return null;
+    return await readFile(thumbnailPath);
+  } catch {
+    return null;
+  }
+}
+
+function extractStreamInfo(
+  streams: FFprobeStream[],
+  isVideo: boolean,
+  format?: FFprobeData['format'],
+): { info: string; width?: number; height?: number } {
+  const videoStream = streams.find((s) => s.codec_type === 'video');
+  const width = videoStream?.width;
+  const height = videoStream?.height;
+
+  const parts = streams
+    .map((stream) => {
+      if (stream.codec_type === 'video') {
+        if (!isVideo) return `${stream.codec_name} ${stream.width}x${stream.height}`;
+        const bitrate = stream.bit_rate
+          ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
+          : format?.bit_rate
+            ? `${Math.round(parseInt(format.bit_rate) / 1000)}kbps`
+            : '';
+        return `${stream.codec_name} ${stream.width}x${stream.height}${bitrate ? ` ${bitrate}` : ''}`;
+      }
+      if (stream.codec_type === 'audio') {
+        const bitrate = stream.bit_rate
+          ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
+          : format?.bit_rate
+            ? `${Math.round(parseInt(format.bit_rate) / 1000)}kbps`
+            : '';
+        const sampleRate = stream.sample_rate
+          ? `${Math.round(parseInt(stream.sample_rate) / 1000)}kHz`
+          : '';
+        return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .join(', ');
+
+  return { info: parts, width, height };
+}
+
+// --- Caption Builders ---
+
+function buildSingleCaption(title: string, url: string, item: MediaItem): string {
+  const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
+  const escapedUrl = escapeMarkdownV2(url);
+  const escapedInfo = escapeMarkdownV2(item.streamInfo);
+  const escapedSize = escapeMarkdownV2(item.fileSizeMB);
+  return `[${escapedTitle}](${escapedUrl})\n\`${escapedInfo}, ${escapedSize}MB\``;
+}
+
+function buildGroupCaption(
+  title: string,
+  url: string,
+  chunk: MediaItem[],
+  isFirstChunk: boolean,
+): string {
+  const imageFormats = new Map<string, { count: number; dimensions: string }>();
+  const videoFormats = new Map<string, { count: number; dimensions: string; codec: string }>();
+  let chunkTotalSize = 0;
+
+  for (const item of chunk) {
+    if (item.isVideo) {
+      const [codec, dimensions] = item.streamInfo.split(' ');
+      const existing = videoFormats.get(dimensions) || { count: 0, dimensions, codec };
+      videoFormats.set(dimensions, { ...existing, count: existing.count + 1 });
+    } else {
+      const dimensions = item.streamInfo;
+      const existing = imageFormats.get(dimensions) || { count: 0, dimensions };
+      imageFormats.set(dimensions, { ...existing, count: existing.count + 1 });
+    }
+    chunkTotalSize += parseFloat(item.fileSizeMB);
+  }
+
+  const formatParts: string[] = [];
+  if (imageFormats.size > 0) {
+    const summary = Array.from(imageFormats.values())
+      .map((info) => {
+        const [codec, dims] = info.dimensions.split(' ');
+        return `${info.count} ${codec} image${info.count > 1 ? 's' : ''} at ${dims}`;
+      })
+      .join(', ');
+    formatParts.push(summary);
+  }
+  if (videoFormats.size > 0) {
+    const summary = Array.from(videoFormats.values())
+      .map(
+        (info) =>
+          `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
+      )
+      .join(', ');
+    formatParts.push(summary);
+  }
+
+  const escapedSummary = escapeMarkdownV2(formatParts.join(', '));
+  const escapedSize = escapeMarkdownV2(chunkTotalSize.toFixed(1));
+  const sizeLabel = `\`${escapedSummary}, ${escapedSize}MB total\``;
+
+  if (isFirstChunk) {
+    const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
+    const escapedUrl = escapeMarkdownV2(url);
+    return `[${escapedTitle}](${escapedUrl})\n${sizeLabel}`;
+  }
+  return sizeLabel;
+}
+
+// --- Main Handler ---
 
 export async function handleMessage(ctx: Context): Promise<void> {
   const messageText = ctx.message?.text;
@@ -101,15 +255,12 @@ export async function handleMessage(ctx: Context): Promise<void> {
   const chatType = ctx.chat?.type;
   const isAnonymousAdmin = ctx.from?.username === 'GroupAnonymousBot';
 
-  // Create context object for logging
   const logContext = {
     type: chatType,
     chat: chatId,
     from: isAnonymousAdmin ? 'AnonymousAdmin' : username || userId,
     msgId: messageId,
   };
-
-  // Create user identifier string
   const userInfo = isAnonymousAdmin
     ? 'Anonymous Admin'
     : username
@@ -117,36 +268,14 @@ export async function handleMessage(ctx: Context): Promise<void> {
       : `user ${userId}`;
   const requestId = `[${chatId}:${messageId}]`;
 
-  /**
-   * Normalizes line breaks in text to have at most one empty line between content
-   */
-  function normalizeLineBreaks(text: string): string {
-    return text
-      .replace(/\r\n/g, '\n') // Normalize Windows line endings
-      .replace(/^\s*(.)\s*$/gm, (match, _) => {
-        // Keep lines that aren't just a single character with optional whitespace
-        return match.trim().length > 1 ? match : '';
-      }) // Remove lines containing only a single character
-      .replace(/(\n\s*(.)\s*\n\s*\2\s*\n\s*)+/g, '\n') // Replace repeating single-character lines with single newline
-      .replace(/\n\s*\n+/g, '\n') // Replace multiple newlines with single newline
-      .trim();
-  }
-
   if (!messageText || !chatId) {
     logger.warn('Skipping message due to missing text or chatId', logContext);
     return;
   }
 
-  // Apply rate limiting to regular users (not anonymous admins)
   if (userId && !isAnonymousAdmin) {
-    const rateLimiter = RateLimiter.getInstance();
-
-    // Check if user is allowed to make a request
-    if (!rateLimiter.canMakeRequest(userId)) {
-      logger.info(`Rate limit applied for ${userInfo}`, {
-        ...logContext,
-        requestId: `[${chatId}]`,
-      });
+    if (!RateLimiter.getInstance().tryConsume(userId)) {
+      logger.info(`Rate limit applied for ${userInfo}`, { ...logContext, requestId });
       await ctx.reply('You are sending requests too quickly. Please try again later.', {
         reply_to_message_id: messageId,
       });
@@ -155,363 +284,229 @@ export async function handleMessage(ctx: Context): Promise<void> {
   }
 
   try {
-    // Extract URLs from message
     const words = messageText.split(/\s+/);
     const urls = words.filter((word) => isValidUrl(word) && isSupportedPlatform(word));
-
     if (urls.length === 0) return;
 
     const url = urls[0];
     logger.info(`${userInfo} requested: ${url}`, { ...logContext, requestId });
 
-    // Record rate limit usage for non-anonymous users
-    if (userId && !isAnonymousAdmin) {
-      RateLimiter.getInstance().recordRequest(userId);
+    await downloadSemaphore.run(() =>
+      processMediaRequest(ctx, url, chatId, messageId!, logContext, requestId, userInfo),
+    );
+  } catch (error) {
+    logger.error('Failed to process message', { error });
+    await ctx.reply('Failed to process message').catch(() => {});
+  }
+}
+
+async function processMediaRequest(
+  ctx: Context,
+  url: string,
+  chatId: number,
+  messageId: number,
+  logContext: Record<string, unknown>,
+  requestId: string,
+  userInfo: string,
+): Promise<void> {
+  const downloader = MediaDownloader.getInstance();
+  const actionManager = new ChatActionManager(ctx, chatId);
+
+  try {
+    await actionManager.start('typing');
+
+    logger.info('Fetching media info...', { ...logContext, requestId });
+    const mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
+      maxAttempts: 5,
+      initialDelay: 2000,
+      maxDelay: 15000,
+    });
+
+    if (!mediaInfo) {
+      logger.warn('Failed to get media information after retries', { ...logContext, requestId });
+      await ctx.reply('Failed to get media information after several attempts', {
+        reply_to_message_id: messageId,
+      });
+      return;
     }
 
-    const downloader = MediaDownloader.getInstance();
-    const actionManager = new ChatActionManager(ctx, chatId);
+    const action: ChatAction =
+      mediaInfo.format === 'audio'
+        ? 'upload_voice'
+        : mediaInfo.format === 'image'
+          ? 'upload_photo'
+          : 'upload_video';
+    await actionManager.start(action);
 
-    try {
-      await actionManager.start('typing');
-
-      // Get media info first to determine format
-      logger.info('Fetching media info...', { ...logContext, requestId });
-      const mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
-        maxAttempts: 5,
-        initialDelay: 2000,
-        maxDelay: 15000,
-      });
-
-      if (!mediaInfo) {
-        actionManager.stop();
-        logger.warn('Failed to get media information after retries', { ...logContext, requestId });
-        await ctx.reply('Failed to get media information after several attempts', {
-          reply_to_message_id: messageId,
-        });
-        return;
-      }
-
-      // Switch to appropriate action for media type
-      const action =
-        mediaInfo.format === 'audio'
-          ? 'upload_voice'
-          : mediaInfo.format === 'image'
-            ? 'upload_photo'
-            : 'upload_video';
-      await actionManager.start(action);
-
-      // Download the media
-      logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
-      const result = await withRetry(
-        () =>
-          downloader.download(url, {
+    logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
+    const result = await withRetry(
+      () =>
+        downloader.download(
+          url,
+          {
             maxFileSize: env.MAX_FILE_SIZE,
             timeout: env.DOWNLOAD_TIMEOUT,
             format: mediaInfo.format,
-          }),
-        {
-          maxAttempts: 3,
-          initialDelay: 3000,
-          maxDelay: 20000,
-        },
-      );
+          },
+          mediaInfo,
+        ),
+      { maxAttempts: 3, initialDelay: 3000, maxDelay: 20000 },
+    );
 
-      // Stop the action before processing result
-      actionManager.stop();
+    actionManager.stop();
 
-      if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
-        const errorMessage = result.error || 'Unknown error';
-        logger.error(`Failed to process media after retries: ${errorMessage}`, null, {
-          ...logContext,
-          requestId,
-        });
-        await ctx.reply(`Failed to process media after several attempts: ${errorMessage}`, {
-          reply_to_message_id: messageId,
-        });
-        return;
-      }
-
-      // Get stream info for each file
-      const mediaInfos = await Promise.all(
-        result.filePaths.map(async (path) => {
-          const { stdout: ffprobeOutput } = await execAsync(
-            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`,
-          );
-          return JSON.parse(ffprobeOutput) as FFprobeData;
-        }),
-      );
-
-      // Format stream info for each file
-      const mediaItems = await Promise.all(
-        result.filePaths.map(async (path, index) => {
-          const info = mediaInfos[index];
-          const isVideo = path.endsWith('.mp4');
-          let thumbnail: InputFile | undefined;
-
-          if (isVideo) {
-            try {
-              logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
-              const thumbnailPath = `${path}.thumb.jpg`;
-
-              // Extract first frame as thumbnail, scaled to Telegram's 320px limit
-              await execAsync(
-                `ffmpeg -y -i "${path}" -vf "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease" -q:v 6 -frames:v 1 "${thumbnailPath}"`,
-              );
-
-              // Verify file meets Telegram's thumbnail requirements (non-empty, <=200KB)
-              const stats = await statAsync(thumbnailPath);
-              if (stats.size === 0 || stats.size > 200 * 1024) {
-                throw new Error('Thumbnail must be non-empty and <= 200KB');
-              }
-
-              logger.debug('Thumbnail created successfully', {
-                ...logContext,
-                requestId,
-                size: stats.size,
-              });
-              thumbnail = new InputFile(createReadStream(thumbnailPath));
-            } catch (error) {
-              logger.warn('Failed to create thumbnail', { ...logContext, requestId, error });
-            }
-          }
-
-          let videoWidth: number | undefined;
-          let videoHeight: number | undefined;
-          const streamInfo = info.streams
-            .map((stream) => {
-              if (stream.codec_type === 'video') {
-                videoWidth = stream.width;
-                videoHeight = stream.height;
-                // For images, only show codec and dimensions
-                if (!isVideo) {
-                  return `${stream.codec_name} ${stream.width}x${stream.height}`;
-                }
-                // For videos, include bitrate
-                const bitrate = stream.bit_rate
-                  ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
-                  : info.format?.bit_rate
-                    ? `${Math.round(parseInt(info.format.bit_rate) / 1000)}kbps`
-                    : '';
-                return `${stream.codec_name} ${stream.width}x${stream.height}${bitrate ? ` ${bitrate}` : ''}`;
-              } else if (stream.codec_type === 'audio') {
-                const bitrate = stream.bit_rate
-                  ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
-                  : info.format?.bit_rate
-                    ? `${Math.round(parseInt(info.format.bit_rate) / 1000)}kbps`
-                    : '';
-                const sampleRate = stream.sample_rate
-                  ? `${Math.round(parseInt(stream.sample_rate) / 1000)}kHz`
-                  : '';
-                return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
-              }
-              return null;
-            })
-            .filter(Boolean)
-            .join(', ');
-
-          // Get file size
-          const fileSize = info.format?.size ? parseInt(info.format.size) : 0;
-          const fileSizeMB = fileSize ? (fileSize / (1024 * 1024)).toFixed(1) : '0';
-
-          // Check file size before attempting to send
-          if (fileSize > env.MAX_FILE_SIZE) {
-            logger.warn(
-              `File size ${fileSizeMB}MB exceeds limit of ${env.MAX_FILE_SIZE / 1024 / 1024}MB`,
-              { ...logContext, requestId },
-            );
-            throw new Error(
-              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`,
-            );
-          }
-
-          return {
-            path,
-            isVideo,
-            thumbnail,
-            videoWidth,
-            videoHeight,
-            streamInfo,
-            fileSizeMB,
-          };
-        }),
-      );
-
-      // Escape special characters for MarkdownV2
-      const escapedTitle = normalizeLineBreaks(result.mediaInfo.title).replace(
-        /[_*[\]()~`>#+\-=|{}.!\\]/g,
-        '\\$&',
-      );
-      const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-      // Create a summary for multiple files
-      let caption: string;
-      if (mediaItems.length > 1) {
-        // Split into chunks of 10 (Telegram's limit)
-        const chunkSize = 10;
-        for (let i = 0; i < mediaItems.length; i += chunkSize) {
-          const chunk = mediaItems.slice(i, i + chunkSize);
-
-          // Group files by type and format
-          const imageFormats = new Map<string, { count: number; dimensions: string }>();
-          const videoFormats = new Map<
-            string,
-            { count: number; dimensions: string; codec: string }
-          >();
-          let chunkTotalSize = 0;
-
-          chunk.forEach((item) => {
-            if (item.isVideo) {
-              const [codec, dimensions] = item.streamInfo.split(' ');
-              const key = `${dimensions}`; // Use dimensions as key to group by resolution
-              const existing = videoFormats.get(key) || { count: 0, dimensions, codec };
-              videoFormats.set(key, { ...existing, count: existing.count + 1 });
-            } else {
-              const dimensions = item.streamInfo;
-              const key = dimensions;
-              const existing = imageFormats.get(key) || { count: 0, dimensions };
-              imageFormats.set(key, { ...existing, count: existing.count + 1 });
-            }
-            chunkTotalSize += parseFloat(item.fileSizeMB);
-          });
-
-          const formatSummary = [];
-          if (imageFormats.size > 0) {
-            const imageSummary = Array.from(imageFormats.entries())
-              .map(([_, info]) => {
-                const [codec, dimensions] = info.dimensions.split(' ');
-                return `${info.count} ${codec} image${info.count > 1 ? 's' : ''} at ${dimensions}`;
-              })
-              .join(', ');
-            formatSummary.push(imageSummary);
-          }
-          if (videoFormats.size > 0) {
-            const videoSummary = Array.from(videoFormats.entries())
-              .map(
-                ([_, info]) =>
-                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
-              )
-              .join(', ');
-            formatSummary.push(videoSummary);
-          }
-
-          const escapedSummary = formatSummary
-            .join(', ')
-            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-          const escapedSize = chunkTotalSize
-            .toFixed(1)
-            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-          // Create chunk-specific caption
-          const chunkCaption =
-            i === 0
-              ? `[${escapedTitle}](${escapedUrl})\n` +
-                `\`${escapedSummary}, ${escapedSize}MB total\``
-              : `\`${escapedSummary}, ${escapedSize}MB total\``;
-
-          // Send as media group for multiple items
-          const mediaGroup = chunk.map((item, index) => {
-            if (item.isVideo) {
-              return {
-                type: 'video' as const,
-                media: new InputFile(createReadStream(item.path)),
-                ...(index === 0
-                  ? {
-                      caption: chunkCaption,
-                      parse_mode: 'MarkdownV2' as const,
-                    }
-                  : {}),
-                ...(item.thumbnail && { thumbnail: item.thumbnail }),
-                ...(item.videoWidth &&
-                  item.videoHeight && {
-                    width: item.videoWidth,
-                    height: item.videoHeight,
-                  }),
-              };
-            } else {
-              return {
-                type: 'photo' as const,
-                media: new InputFile(createReadStream(item.path)),
-                ...(index === 0
-                  ? {
-                      caption: chunkCaption,
-                      parse_mode: 'MarkdownV2' as const,
-                    }
-                  : {}),
-              };
-            }
-          });
-          await ctx.replyWithMediaGroup(mediaGroup, {
-            reply_to_message_id: messageId,
-          });
-        }
-      } else {
-        // Single file - use detailed info
-        const escapedInfo = mediaItems[0].streamInfo.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-        const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-        caption = [`[${escapedTitle}](${escapedUrl})`, `\`${escapedInfo}, ${escapedSize}MB\``].join(
-          '\n',
-        );
-
-        const item = mediaItems[0];
-        if (result.mediaInfo.format === 'audio') {
-          await ctx.replyWithVoice(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-          });
-        } else if (item.isVideo) {
-          await ctx.replyWithVideo(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-            ...(item.thumbnail && { thumbnail: item.thumbnail }),
-            ...(item.videoWidth &&
-              item.videoHeight && {
-                width: item.videoWidth,
-                height: item.videoHeight,
-              }),
-          });
-        } else {
-          await ctx.replyWithPhoto(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-          });
-        }
-      }
-
-      // Clean up all files including thumbnails
-      await Promise.all(
-        mediaItems.flatMap(async (item) => {
-          const files = [item.path];
-          if (item.isVideo) {
-            files.push(`${item.path}.thumb.jpg`);
-          }
-          return Promise.all(
-            files.map((file) =>
-              downloader
-                .cleanup(file)
-                .catch((error) =>
-                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-                ),
-            ),
-          );
-        }),
-      );
-      logger.debug(`Successfully processed media request for ${userInfo}`, {
+    if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
+      logger.error('Failed to process media after retries', {
         ...logContext,
         requestId,
+        error: result.error,
       });
-    } catch (error) {
-      logger.error('Failed to process media request', error);
-      await ctx.reply('Failed to process media request', {
+      await ctx.reply('Failed to process media. Please try a different URL.', {
         reply_to_message_id: messageId,
       });
+      return;
     }
+
+    const mediaItems = await buildMediaItems(result.filePaths, logContext, requestId);
+
+    if (mediaItems.length > 1) {
+      await sendMediaGroup(ctx, mediaItems, result.mediaInfo, url, messageId);
+    } else {
+      await sendSingleMedia(ctx, mediaItems[0], result.mediaInfo, url, messageId);
+    }
+
+    await Promise.all(
+      mediaItems.map(async (item) => {
+        const files = [item.path];
+        if (item.isVideo) files.push(`${item.path}.thumb.jpg`);
+        await Promise.all(
+          files.map((file) =>
+            downloader
+              .cleanup(file)
+              .catch((error) =>
+                logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
+              ),
+          ),
+        );
+      }),
+    );
+
+    logger.debug(`Successfully processed media request for ${userInfo}`, {
+      ...logContext,
+      requestId,
+    });
   } catch (error) {
-    logger.error('Failed to process message', error);
-    await ctx.reply('Failed to process message');
+    logger.error('Failed to process media request', { error });
+    await ctx
+      .reply('Failed to process media request', { reply_to_message_id: messageId })
+      .catch(() => {});
+  } finally {
+    actionManager.stop();
+  }
+}
+
+async function buildMediaItems(
+  filePaths: string[],
+  logContext: Record<string, unknown>,
+  requestId: string,
+): Promise<MediaItem[]> {
+  return Promise.all(
+    filePaths.map(async (path) => {
+      assertSafePath(path, env.TMP_DIR);
+      const probe = await probeMediaFile(path);
+      const isVideo = path.endsWith('.mp4');
+
+      let thumbnail: Buffer | null = null;
+      if (isVideo) {
+        logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
+        thumbnail = await generateThumbnail(path);
+        if (thumbnail) {
+          logger.debug('Thumbnail created successfully', {
+            ...logContext,
+            requestId,
+            size: thumbnail.length,
+          });
+        }
+      }
+
+      const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
+      const fileSize = probe.format?.size ? parseInt(probe.format.size) : 0;
+      const fileSizeMB = fileSize ? (fileSize / BYTES_PER_MB).toFixed(1) : '0';
+
+      if (fileSize > env.MAX_FILE_SIZE) {
+        throw new Error(
+          `Media file (${fileSizeMB}MB) exceeds size limit (${env.MAX_FILE_SIZE / BYTES_PER_MB}MB)`,
+        );
+      }
+
+      return {
+        path,
+        isVideo,
+        thumbnail: thumbnail ?? undefined,
+        videoWidth: width,
+        videoHeight: height,
+        streamInfo: info,
+        fileSizeMB,
+      };
+    }),
+  );
+}
+
+async function sendMediaGroup(
+  ctx: Context,
+  mediaItems: MediaItem[],
+  mediaInfo: { title: string },
+  url: string,
+  messageId: number,
+): Promise<void> {
+  for (let i = 0; i < mediaItems.length; i += MAX_MEDIA_GROUP_SIZE) {
+    const chunk = mediaItems.slice(i, i + MAX_MEDIA_GROUP_SIZE);
+    const caption = buildGroupCaption(mediaInfo.title, url, chunk, i === 0);
+
+    const mediaGroup = chunk.map((item, index) => {
+      const captionOpts = index === 0 ? { caption, parse_mode: 'MarkdownV2' as const } : {};
+
+      if (item.isVideo) {
+        return {
+          type: 'video' as const,
+          media: new InputFile(item.path),
+          ...captionOpts,
+          ...(item.thumbnail && { thumbnail: new InputFile(item.thumbnail) }),
+          ...(item.videoWidth &&
+            item.videoHeight && { width: item.videoWidth, height: item.videoHeight }),
+        };
+      }
+      return {
+        type: 'photo' as const,
+        media: new InputFile(item.path),
+        ...captionOpts,
+      };
+    });
+
+    await ctx.replyWithMediaGroup(mediaGroup, { reply_to_message_id: messageId });
+  }
+}
+
+async function sendSingleMedia(
+  ctx: Context,
+  item: MediaItem,
+  mediaInfo: { title: string; format: string },
+  url: string,
+  messageId: number,
+): Promise<void> {
+  const caption = buildSingleCaption(mediaInfo.title, url, item);
+  const baseOpts = { caption, reply_to_message_id: messageId, parse_mode: 'MarkdownV2' as const };
+
+  if (mediaInfo.format === 'audio') {
+    await ctx.replyWithVoice(new InputFile(item.path), baseOpts);
+  } else if (item.isVideo) {
+    await ctx.replyWithVideo(new InputFile(item.path), {
+      ...baseOpts,
+      ...(item.thumbnail && { thumbnail: new InputFile(item.thumbnail) }),
+      ...(item.videoWidth &&
+        item.videoHeight && { width: item.videoWidth, height: item.videoHeight }),
+    });
+  } else {
+    await ctx.replyWithPhoto(new InputFile(item.path), baseOpts);
   }
 }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,96 +1,185 @@
 import { Context, InputFile } from 'grammy';
-import { isValidUrl, isSupportedPlatform } from '../utils/url.js';
+import { access, stat } from 'fs/promises';
+import { isSupportedUrl } from '../utils/url.js';
 import { MediaDownloader } from '../services/downloader.js';
+import type { MediaMetadata } from '../services/downloader.js';
+import { probeMediaFile, extractStreamInfo, scaleThumbnail } from '../services/mediaProbe.js';
 import { env } from '../config/env.js';
-import { createReadStream, stat } from 'fs';
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
 import { RateLimiter } from '../utils/rateLimit.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import { buildSingleCaption, buildGroupCaption } from '../utils/caption.js';
+import { Semaphore } from '../utils/concurrency.js';
+import { ChatActionManager } from '../utils/chatAction.js';
+import type { ChatAction } from '../utils/chatAction.js';
+import { normalizeUrl } from '../utils/urlNormalize.js';
+import { withTelegramFlood } from '../utils/telegramFlood.js';
+import { getCooldownRemainingMs } from '../utils/hostCooldown.js';
 
-const execAsync = promisify(exec);
-const statAsync = promisify(stat);
+const BYTES_PER_MB = 1024 * 1024;
+const MAX_MEDIA_GROUP_SIZE = 10;
+const MAX_CONCURRENT_DOWNLOADS = 5;
+const MAX_CONCURRENT_PROBES = 10;
+const DOWNLOAD_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
+// Byte cap on the on-disk cache so a busy chat can't fill the tmpfs across the
+// 7-day TTL (entry count is meaningless when one album can be ~500MB). On
+// overflow the oldest entries that aren't mid-send are evicted to make room.
+const CACHE_MAX_BYTES = 512 * 1024 * 1024;
+// Aggregate cap across all files in a single album (post-probe check).
+// Individual per-file limit is env.MAX_FILE_SIZE; this bounds huge galleries.
+const MAX_ALBUM_BYTES = 500 * 1024 * 1024;
+const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
+const probeSemaphore = new Semaphore(MAX_CONCURRENT_PROBES);
 
-type ChatAction =
-  | 'typing'
-  | 'upload_photo'
-  | 'record_video'
-  | 'upload_video'
-  | 'record_voice'
-  | 'upload_voice'
-  | 'upload_document'
-  | 'choose_sticker'
-  | 'find_location'
-  | 'record_video_note'
-  | 'upload_video_note';
+const IMAGE_CODECS = new Set(['mjpeg', 'png', 'gif', 'webp', 'bmp', 'tiff', 'jpeg2000']);
 
-interface FFprobeStream {
-  codec_type: string;
-  codec_name: string;
-  width?: number;
-  height?: number;
-  sample_rate?: string;
-  bit_rate?: string;
+// --- Download Cache ---
+
+interface MediaItem {
+  path: string;
+  isVideo: boolean;
+  thumbnailPath?: string;
+  videoWidth?: number;
+  videoHeight?: number;
+  streamInfo: string;
+  fileSizeBytes: number;
+  fileSizeMB: string;
 }
 
-interface FFprobeData {
-  streams: FFprobeStream[];
-  format?: {
-    size?: string;
-    bit_rate?: string;
-  };
+interface CachedDownload {
+  mediaInfo: MediaMetadata;
+  mediaItems: MediaItem[];
+  expiry: number;
 }
 
-/**
- * Manages a chat action status with immediate start and cleanup
- */
-class ChatActionManager {
-  private interval: NodeJS.Timeout | null = null;
+const downloadCache = new Map<string, CachedDownload>();
 
-  constructor(
-    private ctx: Context,
-    private chatId: number,
-  ) {}
+// Keys whose files are currently being uploaded. The cache-evict timer must
+// not delete files mid-send, so it skips any key with a live send. Refcounted
+// because concurrent duplicate requests can send the same cached entry.
+const inUseKeys = new Map<string, number>();
+function markInUse(key: string): void {
+  inUseKeys.set(key, (inUseKeys.get(key) ?? 0) + 1);
+}
+function unmarkInUse(key: string): void {
+  const next = (inUseKeys.get(key) ?? 1) - 1;
+  if (next <= 0) {
+    inUseKeys.delete(key);
+    // A finished send may have been the only thing pinning the cache over
+    // budget (trimCacheToBudget can't evict in-use entries) — reclaim now.
+    trimCacheToBudget(MediaDownloader.getInstance());
+  } else {
+    inUseKeys.set(key, next);
+  }
+}
 
-  async start(action: ChatAction): Promise<void> {
-    try {
-      // Clear any existing interval
-      this.stop();
+function entryBytes(entry: CachedDownload): number {
+  return entry.mediaItems.reduce((sum, item) => sum + item.fileSizeBytes, 0);
+}
 
-      // Send action immediately with retry
-      await this.sendActionWithRetry(action);
+// Evict the oldest non-in-use entries (Map preserves insertion order), cleaning
+// their files, until the live cache fits within `budget`. In-use entries can't
+// be evicted, so this is re-run when a send finishes (see unmarkInUse) to keep
+// the cap effectively hard rather than only enforced at insert time.
+function trimCacheToBudget(downloader: MediaDownloader, budget: number = CACHE_MAX_BYTES): void {
+  let total = 0;
+  for (const entry of downloadCache.values()) total += entryBytes(entry);
+  if (total <= budget) return;
+  for (const [key, entry] of downloadCache) {
+    if (total <= budget) break;
+    if (inUseKeys.has(key)) continue;
+    downloadCache.delete(key);
+    total -= entryBytes(entry);
+    for (const item of entry.mediaItems) {
+      downloader.cleanup(item.path).catch(() => {});
+      if (item.thumbnailPath) downloader.cleanup(item.thumbnailPath).catch(() => {});
+    }
+  }
+}
 
-      // Set up interval for keeping the action alive
-      this.interval = setInterval(() => {
-        this.sendActionWithRetry(action).catch((error) => {
-          // Only log if it's not a network error (since those will be retried)
-          if (!error.message?.includes('Network request')) {
-            logger.error('Failed to send chat action after retries', error);
+const cacheEvictTimer = setInterval(
+  () => {
+    const now = Date.now();
+    const downloader = MediaDownloader.getInstance();
+    for (const [key, entry] of downloadCache) {
+      if (now > entry.expiry && !inUseKeys.has(key)) {
+        downloadCache.delete(key);
+        for (const item of entry.mediaItems) {
+          downloader
+            .cleanup(item.path)
+            .catch((error) =>
+              logger.warn('Cache evict cleanup failed', { path: item.path, error }),
+            );
+          if (item.thumbnailPath) {
+            downloader.cleanup(item.thumbnailPath).catch((error) =>
+              logger.warn('Cache evict thumb cleanup failed', {
+                path: item.thumbnailPath,
+                error,
+              }),
+            );
           }
-        });
-      }, 1000);
-    } catch (error) {
-      logger.error('Failed to start chat action after retries', error);
-      this.stop();
+        }
+      }
     }
-  }
+  },
+  5 * 60 * 1000,
+);
+cacheEvictTimer.unref();
 
-  private async sendActionWithRetry(action: ChatAction): Promise<void> {
-    await withRetry(() => this.ctx.api.sendChatAction(this.chatId, action), {
-      maxAttempts: 5,
-      initialDelay: 500,
-      maxDelay: 5000,
-    });
-  }
-
-  stop(): void {
-    if (this.interval) {
-      clearInterval(this.interval);
-      this.interval = null;
-    }
-  }
+export function stopCacheEvict(): void {
+  clearInterval(cacheEvictTimer);
 }
+
+async function filesExist(items: MediaItem[]): Promise<boolean> {
+  const checks = await Promise.all(
+    items.flatMap((item) =>
+      [item.path, item.thumbnailPath]
+        .filter((p): p is string => typeof p === 'string')
+        .map((p) =>
+          access(p)
+            .then(() => true)
+            .catch(() => false),
+        ),
+    ),
+  );
+  return checks.every(Boolean);
+}
+
+async function getCachedDownload(url: string): Promise<CachedDownload | null> {
+  const key = normalizeUrl(url);
+  const cached = downloadCache.get(key);
+  if (!cached || Date.now() > cached.expiry) {
+    if (cached) downloadCache.delete(key);
+    return null;
+  }
+  if (await filesExist(cached.mediaItems)) {
+    return cached;
+  }
+  downloadCache.delete(key);
+  return null;
+}
+
+// Tracks downloads currently in progress so concurrent duplicate-URL requests
+// share the single download instead of both writing to the same filename.
+// Resolves to null on download failure; callers handle that themselves.
+const inFlightDownloads = new Map<string, Promise<CachedDownload | null>>();
+
+// Snapshot of files owned by live cache entries — the periodic cleanup sweep
+// skips these so it only reaps true orphans, decoupling it from the cache's own
+// TTL/eviction lifecycle (and from download-tool mtime behaviour).
+export function getCachedFilePaths(): Set<string> {
+  const paths = new Set<string>();
+  for (const entry of downloadCache.values()) {
+    for (const item of entry.mediaItems) {
+      paths.add(item.path);
+      if (item.thumbnailPath) paths.add(item.thumbnailPath);
+    }
+  }
+  return paths;
+}
+
+// --- Main Handler ---
 
 export async function handleMessage(ctx: Context): Promise<void> {
   const messageText = ctx.message?.text;
@@ -101,417 +190,495 @@ export async function handleMessage(ctx: Context): Promise<void> {
   const chatType = ctx.chat?.type;
   const isAnonymousAdmin = ctx.from?.username === 'GroupAnonymousBot';
 
-  // Create context object for logging
-  const logContext = {
-    type: chatType,
-    chat: chatId,
-    from: isAnonymousAdmin ? 'AnonymousAdmin' : username || userId,
-    msgId: messageId,
-  };
-
-  // Create user identifier string
+  const logCtx = { type: chatType, chat: chatId, msgId: messageId };
   const userInfo = isAnonymousAdmin
     ? 'Anonymous Admin'
     : username
       ? `@${username}`
       : `user ${userId}`;
-  const requestId = `[${chatId}:${messageId}]`;
 
-  /**
-   * Normalizes line breaks in text to have at most one empty line between content
-   */
-  function normalizeLineBreaks(text: string): string {
-    return text
-      .replace(/\r\n/g, '\n') // Normalize Windows line endings
-      .replace(/^\s*(.)\s*$/gm, (match, _) => {
-        // Keep lines that aren't just a single character with optional whitespace
-        return match.trim().length > 1 ? match : '';
-      }) // Remove lines containing only a single character
-      .replace(/(\n\s*(.)\s*\n\s*\2\s*\n\s*)+/g, '\n') // Replace repeating single-character lines with single newline
-      .replace(/\n\s*\n+/g, '\n') // Replace multiple newlines with single newline
-      .trim();
-  }
-
-  if (!messageText || !chatId) {
-    logger.warn('Skipping message due to missing text or chatId', logContext);
+  if (!messageText || !chatId || !messageId) {
+    logger.warn('Skipping: missing text, chatId, or messageId', logCtx);
     return;
   }
 
-  // Apply rate limiting to regular users (not anonymous admins)
-  if (userId && !isAnonymousAdmin) {
-    const rateLimiter = RateLimiter.getInstance();
+  try {
+    const trimmed = messageText.trim();
+    // Treat a trailing standalone "+info" token as the info flag — but only as
+    // its own whitespace-delimited token, so a URL that legitimately ends in
+    // "+info" (e.g. .../tag/best+info) isn't corrupted by stripping it.
+    const tokens = trimmed.split(/\s+/);
+    const showInfo = tokens.length > 1 && tokens[tokens.length - 1] === '+info';
+    const textForParsing = showInfo ? tokens.slice(0, -1).join(' ') : trimmed;
 
-    // Check if user is allowed to make a request
-    if (!rateLimiter.canMakeRequest(userId)) {
-      logger.info(`Rate limit applied for ${userInfo}`, {
-        ...logContext,
-        requestId: `[${chatId}]`,
-      });
+    const url = textForParsing.split(/\s+/).find(isSupportedUrl);
+    if (!url) return;
+
+    const rateLimitKey = userId && !isAnonymousAdmin ? userId : chatId;
+    if (!RateLimiter.getInstance().tryConsume(rateLimitKey)) {
+      logger.info(`Rate limited ${userInfo}`, logCtx);
       await ctx.reply('You are sending requests too quickly. Please try again later.', {
-        reply_to_message_id: messageId,
+        reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
       });
       return;
     }
+
+    // Strip query string from the INFO-level log — query params can carry
+    // auth tokens or session ids on some platforms. Full URL still in debug.
+    let loggedUrl = url;
+    try {
+      const u = new URL(url);
+      loggedUrl = `${u.origin}${u.pathname}`;
+    } catch {
+      // keep raw url
+    }
+    logger.info(`${userInfo} → ${loggedUrl}${showInfo ? ' +info' : ''}`, logCtx);
+
+    // Short-circuit if the host is currently in 429-cooldown. Avoids burning
+    // a download slot on a request guaranteed to fail and keeps the user
+    // informed with an accurate retry hint.
+    let cooldownHost: string | null = null;
+    try {
+      cooldownHost = new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      // unparseable — let the pipeline handle it
+    }
+    if (cooldownHost) {
+      const remainingMs = getCooldownRemainingMs(cooldownHost);
+      if (remainingMs > 0) {
+        const seconds = Math.ceil(remainingMs / 1000);
+        logger.info(`Cooldown active for ${cooldownHost} (${seconds}s remaining)`, logCtx);
+        await ctx
+          .reply(
+            `${cooldownHost} is rate-limiting downloads. Please try again in about ${seconds} seconds.`,
+            { reply_parameters: { message_id: messageId, allow_sending_without_reply: true } },
+          )
+          .catch(() => {});
+        return;
+      }
+    }
+
+    await processMediaRequest(ctx, url, chatId, messageId, logCtx, showInfo);
+  } catch (error) {
+    logger.error('Failed to process message', { ...logCtx, error });
+    await ctx.reply('Failed to process message').catch(() => {});
   }
+}
+
+// --- Request Processing ---
+
+async function processMediaRequest(
+  ctx: Context,
+  url: string,
+  chatId: number,
+  messageId: number,
+  logCtx: Record<string, unknown>,
+  showInfo: boolean,
+): Promise<void> {
+  // Check cache first — pure cache hits skip the action manager entirely.
+  const cached = await getCachedDownload(url);
+  if (cached) {
+    logger.info('Cache hit — re-sending', logCtx);
+    await sendResult(ctx, cached, url, messageId, showInfo);
+    return;
+  }
+
+  const actionManager = new ChatActionManager(ctx, chatId);
+  try {
+    await actionManager.start('typing');
+
+    // If another request is already downloading this URL, wait for it.
+    // Otherwise re-check the cache (a concurrent request may have completed
+    // between our initial check and now) before starting a fresh download.
+    const key = normalizeUrl(url);
+    let promise = inFlightDownloads.get(key);
+    if (promise) {
+      logger.info('Awaiting in-flight download', logCtx);
+    } else {
+      // Register the in-flight promise synchronously (no await between the get
+      // and the set) so two concurrent requests for the same URL can't both miss
+      // the map and start duplicate downloads to the same filename. The post-lock
+      // cache recheck and the download both run inside this promise; the download
+      // slot is acquired only around the actual download.
+      promise = (async (): Promise<CachedDownload | null> => {
+        const recheck = await getCachedDownload(url);
+        if (recheck) {
+          logger.info('Cache hit (post-lock) — re-sending', logCtx);
+          return recheck;
+        }
+        return runDownloadPipeline(url, actionManager, logCtx);
+      })().finally(() => inFlightDownloads.delete(key));
+      inFlightDownloads.set(key, promise);
+    }
+
+    const result = await promise;
+
+    if (!result) {
+      await ctx
+        .reply('Failed to process media. Please try a different URL.', {
+          reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
+        })
+        .catch(() => {});
+      return;
+    }
+
+    await sendResult(ctx, result, url, messageId, showInfo);
+  } catch (error) {
+    logger.error('Failed to process media request', { ...logCtx, error });
+    await ctx
+      .reply('Failed to process media request', {
+        reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
+      })
+      .catch(() => {});
+  } finally {
+    actionManager.stop();
+  }
+}
+
+async function sendResult(
+  ctx: Context,
+  result: CachedDownload,
+  url: string,
+  messageId: number,
+  showInfo: boolean,
+): Promise<void> {
+  // Pin the cache key while uploading so the evict timer can't delete the files
+  // from under an in-progress send (e.g. a slow album read near TTL expiry).
+  const key = normalizeUrl(url);
+  markInUse(key);
+  try {
+    if (result.mediaItems.length > 1) {
+      await sendMediaGroup(ctx, result.mediaItems, result.mediaInfo, url, messageId, showInfo);
+    } else {
+      await sendSingleMedia(ctx, result.mediaItems[0], result.mediaInfo, url, messageId, showInfo);
+    }
+  } finally {
+    unmarkInUse(key);
+  }
+}
+
+/**
+ * Runs fetch info → download → probe → cache. Returns the cached entry on
+ * success, or null on failure (with files cleaned up). Shared across
+ * concurrent duplicate-URL requests via inFlightDownloads so only one
+ * actual download ever hits the filesystem for a given URL.
+ */
+async function runDownloadPipeline(
+  url: string,
+  actionManager: ChatActionManager,
+  logCtx: Record<string, unknown>,
+): Promise<CachedDownload | null> {
+  const downloader = MediaDownloader.getInstance();
+  let filePaths: string[] = [];
+  let mediaItems: MediaItem[] = [];
+  let cached = false;
 
   try {
-    // Extract URLs from message
-    const words = messageText.split(/\s+/);
-    const urls = words.filter((word) => isValidUrl(word) && isSupportedPlatform(word));
+    const mediaInfo = await fetchMediaInfo(downloader, url, actionManager, logCtx);
+    if (!mediaInfo) return null;
 
-    if (urls.length === 0) return;
-
-    const url = urls[0];
-    logger.info(`${userInfo} requested: ${url}`, { ...logContext, requestId });
-
-    // Record rate limit usage for non-anonymous users
-    if (userId && !isAnonymousAdmin) {
-      RateLimiter.getInstance().recordRequest(userId);
+    // Hold a download slot only around the actual download — the metadata fetch
+    // (above) and probe/thumbnail work (buildMediaItems, bounded separately by
+    // probeSemaphore) run outside it so they don't throttle other requests' slots.
+    const result = await downloadSemaphore.run(() =>
+      downloadMedia(downloader, url, mediaInfo, actionManager, logCtx),
+    );
+    if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
+      logger.error('Download failed', { ...logCtx, error: result.error });
+      return null;
     }
 
-    const downloader = MediaDownloader.getInstance();
-    const actionManager = new ChatActionManager(ctx, chatId);
+    filePaths = result.filePaths;
+    mediaItems = await buildMediaItems(filePaths);
 
-    try {
-      await actionManager.start('typing');
+    const key = normalizeUrl(url);
+    const existing = downloadCache.get(key);
+    if (existing && Date.now() <= existing.expiry && (await filesExist(existing.mediaItems))) {
+      // Lost a cache race for this URL: a valid entry already exists. Serve it
+      // and discard our redundant download so the duplicate files don't leak.
+      await cleanupFiles(filePaths, mediaItems, downloader, logCtx);
+      cached = true; // already cleaned — keep the finally from double-cleaning
+      return existing;
+    }
 
-      // Get media info first to determine format
-      logger.info('Fetching media info...', { ...logContext, requestId });
-      const mediaInfo = await withRetry(() => downloader.getMediaInfo(url), {
-        maxAttempts: 5,
-        initialDelay: 2000,
-        maxDelay: 15000,
-      });
+    const entry: CachedDownload = {
+      mediaInfo: result.mediaInfo,
+      mediaItems,
+      expiry: Date.now() + DOWNLOAD_CACHE_TTL,
+    };
+    trimCacheToBudget(downloader, CACHE_MAX_BYTES - entryBytes(entry));
+    downloadCache.set(key, entry);
+    cached = true;
+    return entry;
+  } catch (error) {
+    logger.error('Download pipeline failed', { ...logCtx, error });
+    return null;
+  } finally {
+    if (!cached) {
+      await cleanupFiles(filePaths, mediaItems, MediaDownloader.getInstance(), logCtx);
+    }
+  }
+}
 
-      if (!mediaInfo) {
-        actionManager.stop();
-        logger.warn('Failed to get media information after retries', { ...logContext, requestId });
-        await ctx.reply('Failed to get media information after several attempts', {
-          reply_to_message_id: messageId,
-        });
-        return;
-      }
+async function fetchMediaInfo(
+  downloader: MediaDownloader,
+  url: string,
+  actionManager: ChatActionManager,
+  logCtx: Record<string, unknown>,
+): Promise<MediaMetadata | null> {
+  await actionManager.start('typing');
+  logger.info('Fetching media info...', logCtx);
+  try {
+    return await withRetry(() => downloader.getMediaInfo(url), {
+      maxAttempts: 3,
+      initialDelay: 1000,
+      maxDelay: 5000,
+    });
+  } catch (error) {
+    logger.warn('Failed to get media info', { ...logCtx, error });
+    return null;
+  }
+}
 
-      // Switch to appropriate action for media type
-      const action =
-        mediaInfo.format === 'audio'
-          ? 'upload_voice'
-          : mediaInfo.format === 'image'
-            ? 'upload_photo'
-            : 'upload_video';
-      await actionManager.start(action);
+async function downloadMedia(
+  downloader: MediaDownloader,
+  url: string,
+  mediaInfo: MediaMetadata,
+  actionManager: ChatActionManager,
+  logCtx: Record<string, unknown>,
+): ReturnType<MediaDownloader['download']> {
+  const action: ChatAction =
+    mediaInfo.format === 'audio'
+      ? 'upload_voice'
+      : mediaInfo.format === 'image'
+        ? 'upload_photo'
+        : 'upload_video';
+  await actionManager.start(action);
 
-      // Download the media
-      logger.info(`Downloading ${mediaInfo.format} from ${url}`, { ...logContext, requestId });
-      const result = await withRetry(
-        () =>
-          downloader.download(url, {
-            maxFileSize: env.MAX_FILE_SIZE,
-            timeout: env.DOWNLOAD_TIMEOUT,
-            format: mediaInfo.format,
-          }),
-        {
-          maxAttempts: 3,
-          initialDelay: 3000,
-          maxDelay: 20000,
-        },
-      );
+  logger.info(`Downloading ${mediaInfo.format}`, logCtx);
+  return withRetry(
+    () =>
+      downloader.download(
+        url,
+        { maxFileSize: env.MAX_FILE_SIZE, timeout: env.DOWNLOAD_TIMEOUT, format: mediaInfo.format },
+        mediaInfo,
+      ),
+    { maxAttempts: 2, initialDelay: 2000, maxDelay: 10000 },
+  );
+}
 
-      // Stop the action before processing result
-      actionManager.stop();
+// --- Media Item Building ---
 
-      if (!result.success || result.filePaths.length === 0 || !result.mediaInfo) {
-        const errorMessage = result.error || 'Unknown error';
-        logger.error(`Failed to process media after retries: ${errorMessage}`, null, {
-          ...logContext,
-          requestId,
-        });
-        await ctx.reply(`Failed to process media after several attempts: ${errorMessage}`, {
-          reply_to_message_id: messageId,
-        });
-        return;
-      }
+async function buildMediaItems(filePaths: string[]): Promise<MediaItem[]> {
+  const results = await Promise.allSettled(
+    filePaths.map((path) =>
+      probeSemaphore.run(async () => {
+        assertSafePath(path, env.TMP_DIR);
+        const probe = await probeMediaFile(path);
 
-      // Get stream info for each file
-      const mediaInfos = await Promise.all(
-        result.filePaths.map(async (path) => {
-          const { stdout: ffprobeOutput } = await execAsync(
-            `ffprobe -v quiet -print_format json -show_format -show_streams "${path}"`,
-          );
-          return JSON.parse(ffprobeOutput) as FFprobeData;
-        }),
-      );
-
-      // Format stream info for each file
-      const mediaItems = await Promise.all(
-        result.filePaths.map(async (path, index) => {
-          const info = mediaInfos[index];
-          const isVideo = path.endsWith('.mp4');
-          let thumbnail: InputFile | undefined;
-
-          if (isVideo) {
-            try {
-              logger.debug('Creating thumbnail for video', { ...logContext, requestId, path });
-              const thumbnailPath = `${path}.thumb.jpg`;
-
-              // Extract first frame as thumbnail, scaled to Telegram's 320px limit
-              await execAsync(
-                `ffmpeg -y -i "${path}" -vf "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease" -q:v 6 -frames:v 1 "${thumbnailPath}"`,
-              );
-
-              // Verify file meets Telegram's thumbnail requirements (non-empty, <=200KB)
-              const stats = await statAsync(thumbnailPath);
-              if (stats.size === 0 || stats.size > 200 * 1024) {
-                throw new Error('Thumbnail must be non-empty and <= 200KB');
-              }
-
-              logger.debug('Thumbnail created successfully', {
-                ...logContext,
-                requestId,
-                size: stats.size,
-              });
-              thumbnail = new InputFile(createReadStream(thumbnailPath));
-            } catch (error) {
-              logger.warn('Failed to create thumbnail', { ...logContext, requestId, error });
-            }
-          }
-
-          let videoWidth: number | undefined;
-          let videoHeight: number | undefined;
-          const streamInfo = info.streams
-            .map((stream) => {
-              if (stream.codec_type === 'video') {
-                videoWidth = stream.width;
-                videoHeight = stream.height;
-                // For images, only show codec and dimensions
-                if (!isVideo) {
-                  return `${stream.codec_name} ${stream.width}x${stream.height}`;
-                }
-                // For videos, include bitrate
-                const bitrate = stream.bit_rate
-                  ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
-                  : info.format?.bit_rate
-                    ? `${Math.round(parseInt(info.format.bit_rate) / 1000)}kbps`
-                    : '';
-                return `${stream.codec_name} ${stream.width}x${stream.height}${bitrate ? ` ${bitrate}` : ''}`;
-              } else if (stream.codec_type === 'audio') {
-                const bitrate = stream.bit_rate
-                  ? `${Math.round(parseInt(stream.bit_rate) / 1000)}kbps`
-                  : info.format?.bit_rate
-                    ? `${Math.round(parseInt(info.format.bit_rate) / 1000)}kbps`
-                    : '';
-                const sampleRate = stream.sample_rate
-                  ? `${Math.round(parseInt(stream.sample_rate) / 1000)}kHz`
-                  : '';
-                return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
-              }
-              return null;
-            })
-            .filter(Boolean)
-            .join(', ');
-
-          // Get file size
-          const fileSize = info.format?.size ? parseInt(info.format.size) : 0;
-          const fileSizeMB = fileSize ? (fileSize / (1024 * 1024)).toFixed(1) : '0';
-
-          // Check file size before attempting to send
-          if (fileSize > env.MAX_FILE_SIZE) {
-            logger.warn(
-              `File size ${fileSizeMB}MB exceeds limit of ${env.MAX_FILE_SIZE / 1024 / 1024}MB`,
-              { ...logContext, requestId },
-            );
-            throw new Error(
-              `Media file (${fileSizeMB}MB) exceeds Telegram's size limit (${env.MAX_FILE_SIZE / 1024 / 1024}MB)`,
-            );
-          }
-
-          return {
-            path,
-            isVideo,
-            thumbnail,
-            videoWidth,
-            videoHeight,
-            streamInfo,
-            fileSizeMB,
-          };
-        }),
-      );
-
-      // Escape special characters for MarkdownV2
-      const escapedTitle = normalizeLineBreaks(result.mediaInfo.title).replace(
-        /[_*[\]()~`>#+\-=|{}.!\\]/g,
-        '\\$&',
-      );
-      const escapedUrl = url.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-      // Create a summary for multiple files
-      let caption: string;
-      if (mediaItems.length > 1) {
-        // Split into chunks of 10 (Telegram's limit)
-        const chunkSize = 10;
-        for (let i = 0; i < mediaItems.length; i += chunkSize) {
-          const chunk = mediaItems.slice(i, i + chunkSize);
-
-          // Group files by type and format
-          const imageFormats = new Map<string, { count: number; dimensions: string }>();
-          const videoFormats = new Map<
-            string,
-            { count: number; dimensions: string; codec: string }
-          >();
-          let chunkTotalSize = 0;
-
-          chunk.forEach((item) => {
-            if (item.isVideo) {
-              const [codec, dimensions] = item.streamInfo.split(' ');
-              const key = `${dimensions}`; // Use dimensions as key to group by resolution
-              const existing = videoFormats.get(key) || { count: 0, dimensions, codec };
-              videoFormats.set(key, { ...existing, count: existing.count + 1 });
-            } else {
-              const dimensions = item.streamInfo;
-              const key = dimensions;
-              const existing = imageFormats.get(key) || { count: 0, dimensions };
-              imageFormats.set(key, { ...existing, count: existing.count + 1 });
-            }
-            chunkTotalSize += parseFloat(item.fileSizeMB);
-          });
-
-          const formatSummary = [];
-          if (imageFormats.size > 0) {
-            const imageSummary = Array.from(imageFormats.entries())
-              .map(([_, info]) => {
-                const [codec, dimensions] = info.dimensions.split(' ');
-                return `${info.count} ${codec} image${info.count > 1 ? 's' : ''} at ${dimensions}`;
-              })
-              .join(', ');
-            formatSummary.push(imageSummary);
-          }
-          if (videoFormats.size > 0) {
-            const videoSummary = Array.from(videoFormats.entries())
-              .map(
-                ([_, info]) =>
-                  `${info.count} ${info.codec} video${info.count > 1 ? 's' : ''} at ${info.dimensions}`,
-              )
-              .join(', ');
-            formatSummary.push(videoSummary);
-          }
-
-          const escapedSummary = formatSummary
-            .join(', ')
-            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-          const escapedSize = chunkTotalSize
-            .toFixed(1)
-            .replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-          // Create chunk-specific caption
-          const chunkCaption =
-            i === 0
-              ? `[${escapedTitle}](${escapedUrl})\n` +
-                `\`${escapedSummary}, ${escapedSize}MB total\``
-              : `\`${escapedSummary}, ${escapedSize}MB total\``;
-
-          // Send as media group for multiple items
-          const mediaGroup = chunk.map((item, index) => {
-            if (item.isVideo) {
-              return {
-                type: 'video' as const,
-                media: new InputFile(createReadStream(item.path)),
-                ...(index === 0
-                  ? {
-                      caption: chunkCaption,
-                      parse_mode: 'MarkdownV2' as const,
-                    }
-                  : {}),
-                ...(item.thumbnail && { thumbnail: item.thumbnail }),
-                ...(item.videoWidth &&
-                  item.videoHeight && {
-                    width: item.videoWidth,
-                    height: item.videoHeight,
-                  }),
-              };
-            } else {
-              return {
-                type: 'photo' as const,
-                media: new InputFile(createReadStream(item.path)),
-                ...(index === 0
-                  ? {
-                      caption: chunkCaption,
-                      parse_mode: 'MarkdownV2' as const,
-                    }
-                  : {}),
-              };
-            }
-          });
-          await ctx.replyWithMediaGroup(mediaGroup, {
-            reply_to_message_id: messageId,
-          });
-        }
-      } else {
-        // Single file - use detailed info
-        const escapedInfo = mediaItems[0].streamInfo.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-        const escapedSize = mediaItems[0].fileSizeMB.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&');
-
-        caption = [`[${escapedTitle}](${escapedUrl})`, `\`${escapedInfo}, ${escapedSize}MB\``].join(
-          '\n',
+        const isVideo = probe.streams.some(
+          (s) => s.codec_type === 'video' && !IMAGE_CODECS.has(s.codec_name),
         );
 
-        const item = mediaItems[0];
-        if (result.mediaInfo.format === 'audio') {
-          await ctx.replyWithVoice(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-          });
-        } else if (item.isVideo) {
-          await ctx.replyWithVideo(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-            ...(item.thumbnail && { thumbnail: item.thumbnail }),
-            ...(item.videoWidth &&
-              item.videoHeight && {
-                width: item.videoWidth,
-                height: item.videoHeight,
-              }),
-          });
-        } else {
-          await ctx.replyWithPhoto(new InputFile(createReadStream(item.path)), {
-            caption,
-            reply_to_message_id: messageId,
-            parse_mode: 'MarkdownV2',
-          });
-        }
-      }
-
-      // Clean up all files including thumbnails
-      await Promise.all(
-        mediaItems.flatMap(async (item) => {
-          const files = [item.path];
-          if (item.isVideo) {
-            files.push(`${item.path}.thumb.jpg`);
+        // Per-video thumbnail: yt-dlp writes <basename>.jpg alongside each
+        // video via --write-thumbnail. Store the path (not the bytes) so we
+        // don't pin 50-200KB in memory for the whole 7-day cache TTL.
+        let thumbnailPath: string | undefined;
+        if (isVideo) {
+          const candidate = path.replace(/\.[^.]+$/, '.jpg');
+          // Extensionless filenames leave the regex with no match → candidate
+          // === path. Skip entirely rather than point at the media file.
+          if (candidate !== path) {
+            assertSafePath(candidate, env.TMP_DIR);
+            try {
+              await access(candidate);
+              // Downscale to Telegram's ≤320px / <200KB thumbnail constraint;
+              // omit (Telegram auto-generates) if the scale step fails.
+              if (await scaleThumbnail(candidate)) thumbnailPath = candidate;
+            } catch {
+              // No per-video thumb on disk — Telegram auto-generates
+            }
           }
-          return Promise.all(
-            files.map((file) =>
-              downloader
-                .cleanup(file)
-                .catch((error) =>
-                  logger.warn('Failed to cleanup file', { ...logContext, requestId, file, error }),
-                ),
-            ),
+        }
+
+        const { info, width, height } = extractStreamInfo(probe.streams, isVideo, probe.format);
+        // ffprobe doesn't always report format.size; fall back to stat() (the
+        // file is already on disk) so a missing size can't bypass the per-file /
+        // album caps or get cached as 0 bytes (defeating the cache byte budget).
+        const probedSize = probe.format?.size ? parseInt(probe.format.size, 10) : 0;
+        const fileSizeBytes =
+          Number.isFinite(probedSize) && probedSize > 0 ? probedSize : (await stat(path)).size;
+        const fileSizeMB = fileSizeBytes > 0 ? (fileSizeBytes / BYTES_PER_MB).toFixed(1) : '0';
+
+        if (fileSizeBytes > env.MAX_FILE_SIZE) {
+          throw new Error(
+            `Media file (${fileSizeMB}MB) exceeds size limit (${Math.round(env.MAX_FILE_SIZE / BYTES_PER_MB)}MB)`,
           );
-        }),
-      );
-      logger.debug(`Successfully processed media request for ${userInfo}`, {
-        ...logContext,
-        requestId,
-      });
-    } catch (error) {
-      logger.error('Failed to process media request', error);
-      await ctx.reply('Failed to process media request', {
-        reply_to_message_id: messageId,
-      });
-    }
-  } catch (error) {
-    logger.error('Failed to process message', error);
-    await ctx.reply('Failed to process message');
+        }
+
+        return {
+          path,
+          isVideo,
+          thumbnailPath,
+          videoWidth: width,
+          videoHeight: height,
+          streamInfo: info,
+          fileSizeBytes,
+          fileSizeMB,
+        };
+      }),
+    ),
+  );
+
+  const fulfilled: MediaItem[] = [];
+  for (const r of results) {
+    if (r.status === 'rejected') throw r.reason;
+    fulfilled.push(r.value);
   }
+
+  // Aggregate cap: guards against 100-item galleries that fit the per-file
+  // limit but collectively exhaust disk/bandwidth/Telegram upload budget.
+  const totalBytes = fulfilled.reduce((sum, item) => sum + item.fileSizeBytes, 0);
+  if (totalBytes > MAX_ALBUM_BYTES) {
+    throw new Error(
+      `Album total (${(totalBytes / BYTES_PER_MB).toFixed(0)}MB) exceeds limit (${Math.round(MAX_ALBUM_BYTES / BYTES_PER_MB)}MB)`,
+    );
+  }
+
+  return fulfilled;
+}
+
+// --- Telegram Send ---
+
+async function sendMediaGroup(
+  ctx: Context,
+  mediaItems: MediaItem[],
+  mediaInfo: { title: string },
+  url: string,
+  messageId: number,
+  showInfo: boolean,
+): Promise<void> {
+  let sent = 0;
+  for (let i = 0; i < mediaItems.length; i += MAX_MEDIA_GROUP_SIZE) {
+    const chunk = mediaItems.slice(i, i + MAX_MEDIA_GROUP_SIZE);
+    try {
+      if (chunk.length === 1) {
+        // Telegram media groups require 2-10 items; a lone trailing item (album
+        // of 10n+1) must use the single-media path or replyWithMediaGroup 400s.
+        await sendSingleMedia(
+          ctx,
+          chunk[0],
+          { title: mediaInfo.title, format: chunk[0].isVideo ? 'video' : 'image' },
+          url,
+          messageId,
+          showInfo && i === 0,
+        );
+      } else {
+        const caption = showInfo
+          ? buildGroupCaption(mediaInfo.title, url, chunk, i === 0)
+          : undefined;
+        const mediaGroup = chunk.map((item, index) => {
+          const captionOpts =
+            index === 0 && caption ? { caption, parse_mode: 'MarkdownV2' as const } : {};
+          if (item.isVideo) {
+            return {
+              type: 'video' as const,
+              media: new InputFile(item.path),
+              ...captionOpts,
+              ...(item.thumbnailPath && { thumbnail: new InputFile(item.thumbnailPath) }),
+              ...(item.videoWidth &&
+                item.videoHeight && { width: item.videoWidth, height: item.videoHeight }),
+            };
+          }
+          return {
+            type: 'photo' as const,
+            media: new InputFile(item.path),
+            ...captionOpts,
+          };
+        });
+        await withTelegramFlood(() =>
+          ctx.replyWithMediaGroup(mediaGroup, {
+            reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
+          }),
+        );
+      }
+      sent += chunk.length;
+    } catch (error) {
+      // Nothing delivered yet → let the caller report a normal failure.
+      if (sent === 0) throw error;
+      // Some chunks already arrived → don't masquerade as a total failure.
+      logger.warn('Partial album delivery', { sent, total: mediaItems.length, error });
+      await ctx
+        .reply(`Sent ${sent} of ${mediaItems.length} items; the rest failed — please retry.`, {
+          reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
+        })
+        .catch(() => {});
+      return;
+    }
+  }
+}
+
+async function sendSingleMedia(
+  ctx: Context,
+  item: MediaItem,
+  mediaInfo: { title: string; format: string },
+  url: string,
+  messageId: number,
+  showInfo: boolean,
+): Promise<void> {
+  const caption = showInfo ? buildSingleCaption(mediaInfo.title, url, item) : undefined;
+  const baseOpts = {
+    reply_parameters: { message_id: messageId, allow_sending_without_reply: true },
+    ...(caption && { caption, parse_mode: 'MarkdownV2' as const }),
+  };
+
+  if (mediaInfo.format === 'audio') {
+    await withTelegramFlood(() => ctx.replyWithVoice(new InputFile(item.path), baseOpts));
+  } else if (item.isVideo) {
+    await withTelegramFlood(() =>
+      ctx.replyWithVideo(new InputFile(item.path), {
+        ...baseOpts,
+        ...(item.thumbnailPath && { thumbnail: new InputFile(item.thumbnailPath) }),
+        ...(item.videoWidth &&
+          item.videoHeight && { width: item.videoWidth, height: item.videoHeight }),
+      }),
+    );
+  } else {
+    await withTelegramFlood(() => ctx.replyWithPhoto(new InputFile(item.path), baseOpts));
+  }
+}
+
+// --- Cleanup ---
+
+async function cleanupFiles(
+  filePaths: string[],
+  mediaItems: MediaItem[],
+  downloader: MediaDownloader,
+  logCtx: Record<string, unknown>,
+): Promise<void> {
+  const pathsToClean = new Set<string>();
+
+  for (const p of filePaths) {
+    pathsToClean.add(p);
+    // yt-dlp writes a sibling thumbnail (--write-thumbnail) that buildMediaItems
+    // discovers lazily; derive the candidates here too so a throw before/within
+    // buildMediaItems (probe error, size cap) still cleans the sidecar. Covers
+    // the converted .jpg plus a pre-conversion .webp/.png if conversion didn't run.
+    const stem = p.replace(/\.[^.]+$/, '');
+    if (stem !== p) {
+      for (const ext of ['jpg', 'webp', 'png']) pathsToClean.add(`${stem}.${ext}`);
+    }
+  }
+  for (const item of mediaItems) {
+    pathsToClean.add(item.path);
+    if (item.thumbnailPath) pathsToClean.add(item.thumbnailPath);
+  }
+
+  await Promise.all(
+    Array.from(pathsToClean).map((file) =>
+      downloader
+        .cleanup(file)
+        .catch((error) => logger.warn('Cleanup failed', { ...logCtx, file, error })),
+    ),
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { logger } from './utils/logger.js';
 import { Cleanup } from './utils/cleanup.js';
 import { RateLimiter } from './utils/rateLimit.js';
 
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
 async function main(): Promise<void> {
   try {
     await Cleanup.init();
@@ -22,16 +24,26 @@ async function main(): Promise<void> {
       throw error;
     }
 
-    // Graceful shutdown
-    const shutdown = (): void => {
+    const shutdown = async (): Promise<void> => {
       logger.info('Shutting down...');
-      bot.stop();
+      // Hard-exit fallback if graceful shutdown hangs
+      const hardExit = setTimeout(() => {
+        logger.warn('Shutdown timed out, forcing exit');
+        process.exit(1);
+      }, SHUTDOWN_TIMEOUT_MS);
+      hardExit.unref();
+
+      try {
+        await bot.stop();
+      } catch (error) {
+        logger.error('Error stopping bot', { error });
+      }
       Cleanup.stop();
       RateLimiter.getInstance().stop();
-      process.exit(0);
+      process.exitCode = 0;
     };
-    process.on('SIGTERM', shutdown);
-    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', () => void shutdown());
+    process.on('SIGINT', () => void shutdown());
 
     await bot.start({
       onStart: (botInfo) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,14 @@ import { RateLimiter } from './utils/rateLimit.js';
 
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled promise rejection', { error: reason });
+});
+process.on('uncaughtException', (error) => {
+  logger.error('Uncaught exception', { error });
+  process.exit(1);
+});
+
 async function main(): Promise<void> {
   try {
     await Cleanup.init();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,17 @@
 import { createBot } from './bot/index.js';
 import { logger } from './utils/logger.js';
 import { Cleanup } from './utils/cleanup.js';
+import { RateLimiter } from './utils/rateLimit.js';
 
 async function main(): Promise<void> {
   try {
-    // Initialize cleanup
     await Cleanup.init();
     Cleanup.startPeriodicCleanup();
     logger.info('Started cleanup service');
 
-    // Start the bot
     const bot = await createBot();
     logger.info('Starting bot...');
 
-    // Validate token first
     try {
       await bot.api.getMe();
     } catch (error) {
@@ -24,7 +22,17 @@ async function main(): Promise<void> {
       throw error;
     }
 
-    // Start bot with long polling
+    // Graceful shutdown
+    const shutdown = (): void => {
+      logger.info('Shutting down...');
+      bot.stop();
+      Cleanup.stop();
+      RateLimiter.getInstance().stop();
+      process.exit(0);
+    };
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+
     await bot.start({
       onStart: (botInfo) => {
         logger.info(`Bot @${botInfo.username} is starting...`);
@@ -32,12 +40,12 @@ async function main(): Promise<void> {
       drop_pending_updates: true,
     });
   } catch (error) {
-    logger.error('Failed to start bot', error);
+    logger.error('Failed to start bot', { error });
     process.exit(1);
   }
 }
 
 main().catch((error) => {
-  logger.error('Unhandled error in main', error);
+  logger.error('Unhandled error in main', { error });
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,30 @@
 import { createBot } from './bot/index.js';
 import { logger } from './utils/logger.js';
 import { Cleanup } from './utils/cleanup.js';
+import { RateLimiter } from './utils/rateLimit.js';
+import { startVersionCheck, stopVersionCheck } from './services/versionCheck.js';
+import { stopCacheEvict } from './handlers/message.js';
+import { stopPermissionPrune } from './bot/index.js';
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled promise rejection', { error: reason });
+});
+process.on('uncaughtException', (error) => {
+  logger.error('Uncaught exception', { error });
+  process.exit(1);
+});
 
 async function main(): Promise<void> {
   try {
-    // Initialize cleanup
     await Cleanup.init();
     Cleanup.startPeriodicCleanup();
     logger.info('Started cleanup service');
 
-    // Start the bot
     const bot = await createBot();
     logger.info('Starting bot...');
 
-    // Validate token first
     try {
       await bot.api.getMe();
     } catch (error) {
@@ -24,7 +35,35 @@ async function main(): Promise<void> {
       throw error;
     }
 
-    // Start bot with long polling
+    startVersionCheck();
+
+    let isShuttingDown = false;
+    const shutdown = async (): Promise<void> => {
+      if (isShuttingDown) return; // one-shot: a second signal must not run teardown concurrently
+      isShuttingDown = true;
+      logger.info('Shutting down...');
+      // Hard-exit fallback if graceful shutdown hangs
+      const hardExit = setTimeout(() => {
+        logger.warn('Shutdown timed out, forcing exit');
+        process.exit(1);
+      }, SHUTDOWN_TIMEOUT_MS);
+      hardExit.unref();
+
+      try {
+        await bot.stop();
+      } catch (error) {
+        logger.error('Error stopping bot', { error });
+      }
+      Cleanup.stop();
+      RateLimiter.getInstance().stop();
+      stopVersionCheck();
+      stopCacheEvict();
+      stopPermissionPrune();
+      process.exitCode = 0;
+    };
+    process.on('SIGTERM', () => void shutdown());
+    process.on('SIGINT', () => void shutdown());
+
     await bot.start({
       onStart: (botInfo) => {
         logger.info(`Bot @${botInfo.username} is starting...`);
@@ -32,12 +71,12 @@ async function main(): Promise<void> {
       drop_pending_updates: true,
     });
   } catch (error) {
-    logger.error('Failed to start bot', error);
+    logger.error('Failed to start bot', { error });
     process.exit(1);
   }
 }
 
 main().catch((error) => {
-  logger.error('Unhandled error in main', error);
+  logger.error('Unhandled error in main', { error });
   process.exit(1);
 });

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -1,9 +1,9 @@
 import { unlink } from 'fs/promises';
 import { env, getCookieFileForDomain } from '../config/env.js';
-import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
 import { safeExec } from '../utils/exec.js';
 import { assertSafePath } from '../utils/pathSafety.js';
+import { isDomainMatch } from '../utils/url.js';
 import type { DownloadOptions, DownloadResult } from '../types/index.js';
 
 const IMAGE_SITES = [
@@ -62,23 +62,18 @@ export class MediaDownloader {
   private isImageSite(url: string): boolean {
     const domain = this.getHostname(url);
     if (!domain) return false;
-    return IMAGE_SITES.some((site) => domain.endsWith(site));
+    return IMAGE_SITES.some((site) => isDomainMatch(domain, site));
   }
 
   /**
    * Gets media information without downloading.
-   * Single yt-dlp/gallery-dl call per request (no redundant invocations).
+   * Throws on failure so withRetry can retry transient errors.
    */
-  public async getMediaInfo(url: string): Promise<MediaMetadata | null> {
-    try {
-      if (this.isImageSite(url)) {
-        return await this.getGalleryDlInfo(url);
-      }
-      return await this.getYtDlpInfo(url);
-    } catch (error) {
-      logger.error('Failed to get media info', { error });
-      return null;
+  public async getMediaInfo(url: string): Promise<MediaMetadata> {
+    if (this.isImageSite(url)) {
+      return await this.getGalleryDlInfo(url);
     }
+    return await this.getYtDlpInfo(url);
   }
 
   private async getGalleryDlInfo(url: string): Promise<MediaMetadata> {
@@ -115,7 +110,6 @@ export class MediaDownloader {
   }
 
   private async getYtDlpInfo(url: string): Promise<MediaMetadata> {
-    // Single yt-dlp call: get metadata + codec info to determine audio vs video
     const printTemplate = [
       '{',
       '"url": %(url)j,',
@@ -167,30 +161,22 @@ export class MediaDownloader {
 
   /**
    * Downloads media from a URL. Accepts pre-fetched mediaInfo to avoid redundant calls.
+   * Throws on transient errors so withRetry can retry.
    */
   public async download(
     url: string,
     options: DownloadOptions,
     mediaInfo: MediaMetadata,
   ): Promise<DownloadResult> {
-    try {
-      const filePaths = this.isImageSite(url)
-        ? await this.downloadWithGalleryDl(url, options)
-        : await this.downloadWithYtDlp(url, options);
+    const filePaths = this.isImageSite(url)
+      ? await this.downloadWithGalleryDl(url, options)
+      : await this.downloadWithYtDlp(url, options);
 
-      if (filePaths.length === 0) {
-        return { success: false, error: 'No files were downloaded', filePaths: [] };
-      }
-
-      return { success: true, filePaths, mediaInfo };
-    } catch (error) {
-      logger.error('Failed to download media', { error });
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Unknown error occurred',
-        filePaths: [],
-      };
+    if (filePaths.length === 0) {
+      return { success: false, error: 'No files were downloaded', filePaths: [] };
     }
+
+    return { success: true, filePaths, mediaInfo };
   }
 
   private async downloadWithGalleryDl(url: string, options: DownloadOptions): Promise<string[]> {
@@ -204,14 +190,15 @@ export class MediaDownloader {
         '--filename',
         '{filename}.{extension}',
         '--no-mtime',
+        '--range',
+        `1-${MAX_FILES_PER_DOWNLOAD}`,
         ...this.getCookieArgs(url),
         url,
       ],
       { timeout: options.timeout },
     );
 
-    const filePaths = stdout.trim().split('\n').filter(Boolean).slice(0, MAX_FILES_PER_DOWNLOAD);
-
+    const filePaths = stdout.trim().split('\n').filter(Boolean);
     return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
   }
 
@@ -228,6 +215,8 @@ export class MediaDownloader {
         '--output',
         outputTemplate,
         '--restrict-filenames',
+        '--max-filesize',
+        String(options.maxFileSize),
         '--no-download-archive',
         '--no-write-info-json',
         '--no-write-description',

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -137,7 +137,8 @@ export class MediaDownloader {
       url,
     ]);
 
-    const cleanJson = stdout.replace(/: NA,/g, ': null,').replace(/: NA}/g, ': null}');
+    // Only duration uses %(...)s which can emit raw NA; other fields use %(...)j
+    const cleanJson = stdout.replace(/"duration": NA(?=[,}])/g, '"duration": null');
 
     let info: Record<string, unknown>;
     try {
@@ -203,8 +204,12 @@ export class MediaDownloader {
       { timeout: options.timeout },
     );
 
-    const filePaths = stdout.trim().split('\n').filter(Boolean);
-    return filePaths.map((p) => assertSafePath(p.trimEnd(), env.TMP_DIR));
+    const filePaths = stdout
+      .trim()
+      .split('\n')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
   }
 
   private async downloadWithYtDlp(url: string, options: DownloadOptions): Promise<string[]> {

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -1,36 +1,26 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { unlink } from 'fs/promises';
-import type { DownloadOptions, DownloadResult } from '../types/index.js';
+import { env, getCookieFileForDomain } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
-import { getCookieFileForDomain } from '../config/env.js';
+import { safeExec } from '../utils/exec.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import type { DownloadOptions, DownloadResult } from '../types/index.js';
 
-const execAsync = promisify(exec);
+const IMAGE_SITES = [
+  'instagram.com',
+  'twitter.com',
+  'x.com',
+  'pixiv.net',
+  'deviantart.com',
+  'artstation.com',
+];
 
-// Telegram limits (in bytes)
-const TELEGRAM_LIMITS = {
-  STANDARD: 50 * 1024 * 1024, // 50MB for regular bot API
-  LOCAL_SERVER: 2000 * 1024 * 1024, // 2GB with local bot API server
-} as const;
+const MAX_FILES_PER_DOWNLOAD = 100;
 
-/**
- * Escapes a string for shell usage
- */
-function shellEscape(str: string): string {
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
-
-interface FormatInfo {
-  id?: string;
-  ext?: string;
-  filesize?: number;
-  filesize_approx?: number;
-  vcodec?: string;
-  acodec?: string;
-  abr?: number;
-  tbr?: number;
-  format_id: string;
+interface MediaType {
+  url: string;
+  display_url?: string;
+  [key: string]: unknown;
 }
 
 export interface MediaMetadata {
@@ -39,27 +29,13 @@ export interface MediaMetadata {
   duration?: number;
   format: 'audio' | 'video' | 'image';
   thumbnail?: string;
-  formats?: FormatInfo[];
-  filesize?: number;
   mediaTypes?: MediaType[];
-}
-
-interface MediaType {
-  url: string;
-  display_url?: string;
-  [key: string]: unknown;
 }
 
 export class MediaDownloader {
   private static instance: MediaDownloader;
-  private downloadPath: string;
-  private maxFileSize: number;
 
-  private constructor() {
-    this.downloadPath = './tmp';
-    // Use standard limit by default
-    this.maxFileSize = TELEGRAM_LIMITS.STANDARD;
-  }
+  private constructor() {}
 
   public static getInstance(): MediaDownloader {
     if (!MediaDownloader.instance) {
@@ -68,302 +44,147 @@ export class MediaDownloader {
     return MediaDownloader.instance;
   }
 
-  private getYtDlpCookieArgs(url: string): string[] {
-    const args: string[] = [];
+  private getHostname(url: string): string | null {
     try {
-      // Extract domain from URL
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      const cookieFile = getCookieFileForDomain(domain);
-
-      if (cookieFile) {
-        args.push(`--cookies ${shellEscape(cookieFile)}`);
-      }
-    } catch (error) {
-      logger.warn('Failed to parse URL for cookie configuration', { url, error });
-    }
-    return args;
-  }
-
-  private getGalleryDlCookieArgs(url: string): string[] {
-    const args: string[] = [];
-    try {
-      // Extract domain from URL
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      const cookieFile = getCookieFileForDomain(domain);
-
-      if (cookieFile) {
-        args.push(`--cookies ${shellEscape(cookieFile)}`);
-      }
-    } catch (error) {
-      logger.warn('Failed to parse URL for cookie configuration', { url, error });
-    }
-    return args;
-  }
-
-  private isImageSite(url: string): boolean {
-    try {
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      return [
-        'instagram.com',
-        'twitter.com',
-        'x.com',
-        'pixiv.net',
-        'deviantart.com',
-        'artstation.com',
-      ].some((site) => domain.endsWith(site));
+      return new URL(url).hostname.replace(/^www\./, '');
     } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Gets media information without downloading
-   */
-  public async getMediaInfo(url: string): Promise<MediaMetadata | null> {
-    try {
-      if (this.isImageSite(url)) {
-        const command = [
-          'gallery-dl',
-          '-j',
-          ...this.getGalleryDlCookieArgs(url),
-          shellEscape(url),
-        ].join(' ');
-
-        const { stdout, stderr } = await execAsync(command);
-
-        if (stderr) {
-          logger.warn('gallery-dl warning', { command: 'getMediaInfo' });
-        }
-
-        const output = JSON.parse(stdout);
-        // First item contains post metadata
-        const postMetadata = output[0][1];
-        // Remaining items are media
-        const mediaTypes = output.slice(1).map((item: [unknown, string, MediaType]) => {
-          const [, itemUrl, metadata] = item;
-          const { display_url, ...rest } = metadata;
-          return {
-            ...rest,
-            url: display_url || itemUrl,
-          };
-        });
-
-        // Build title from available metadata
-        let title = '';
-        if (postMetadata.tweet_text) {
-          title = postMetadata.tweet_text;
-        } else if (postMetadata.description) {
-          title = postMetadata.description;
-        } else if (postMetadata.text) {
-          title = postMetadata.text;
-        } else if (postMetadata.content) {
-          title = postMetadata.content;
-        } else {
-          title = 'No title';
-        }
-
-        return {
-          url,
-          title,
-          format: 'image',
-          thumbnail: mediaTypes[0]?.display_url,
-          mediaTypes,
-        };
-      }
-
-      // If we get here, use yt-dlp for audio/video content
-      const printTemplate = [
-        '{',
-        '"url": %(url)j,',
-        '"title": %(title)j,',
-        '"duration": %(duration)s,',
-        '"thumbnail": %(thumbnail)j',
-        '}',
-      ].join('');
-
-      const command = [
-        'yt-dlp',
-        '--no-download',
-        `--print ${shellEscape(printTemplate)}`,
-        '--no-playlist',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      // Execute with retries
-      const { stdout, stderr } = await withRetry(() => execAsync(command));
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'getMediaInfo', stderr });
-      }
-
-      const cleanJson = stdout.replace(/: NA,/g, ': null,').replace(/: NA}/g, ': null}');
-      const info = JSON.parse(cleanJson);
-
-      // Get formats with retries only for video/audio content
-      const formats = await withRetry(() => this.getFormats(url));
-      const hasVideo = formats.some((f) => f.vcodec && f.vcodec !== 'none' && f.vcodec !== 'null');
-
-      return {
-        url,
-        title: info.title,
-        duration: info.duration ? Number(info.duration) : undefined,
-        format: hasVideo ? 'video' : 'audio',
-        thumbnail: info.thumbnail,
-        formats,
-      };
-    } catch (error) {
-      logger.error('Failed to get media info', error);
       return null;
     }
   }
 
-  private async getFormats(url: string): Promise<FormatInfo[]> {
-    try {
-      const command = [
-        'yt-dlp',
-        '--no-download',
-        '--print',
-        shellEscape('%(formats)j'),
-        '--no-playlist',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      const { stdout, stderr } = await execAsync(command);
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'getFormats' });
-      }
-
-      return JSON.parse(stdout);
-    } catch (error) {
-      logger.error('Failed to get formats', error);
-      return [];
-    }
+  private getCookieArgs(url: string): string[] {
+    const domain = this.getHostname(url);
+    if (!domain) return [];
+    const cookieFile = getCookieFileForDomain(domain);
+    return cookieFile ? ['--cookies', cookieFile] : [];
   }
 
-  private selectBestFormat(formats: FormatInfo[], options: DownloadOptions): string {
-    const formatSpec =
-      options.format === 'audio'
-        ? 'bestaudio[acodec=opus]/bestaudio'
-        : options.format === 'image'
-          ? 'best[ext=jpg]/best[ext=png]/best[ext=webp]/best'
-          : 'best';
-    logger.debug('Selected format spec', { command: 'selectBestFormat', formatSpec });
-    return formatSpec;
+  private isImageSite(url: string): boolean {
+    const domain = this.getHostname(url);
+    if (!domain) return false;
+    return IMAGE_SITES.some((site) => domain.endsWith(site));
   }
 
   /**
-   * Downloads media from a given URL using yt-dlp
+   * Gets media information without downloading.
+   * Single yt-dlp/gallery-dl call per request (no redundant invocations).
    */
-  public async download(url: string, options: DownloadOptions): Promise<DownloadResult> {
+  public async getMediaInfo(url: string): Promise<MediaMetadata | null> {
     try {
       if (this.isImageSite(url)) {
-        const command = [
-          'gallery-dl',
-          '--download-archive',
-          '/dev/null',
-          '--dest',
-          `'${this.downloadPath}'`,
-          '--filename',
-          '{filename}.{extension}',
-          '--no-mtime',
-          ...this.getGalleryDlCookieArgs(url),
-          shellEscape(url),
-        ].join(' ');
-
-        const { stdout, stderr } = await execAsync(command, { timeout: options.timeout * 1000 });
-
-        if (stderr && !stderr.includes('Failed to open download archive')) {
-          logger.warn('gallery-dl warning', { command: 'download' });
-        }
-
-        const filePaths = stdout.trim().split('\n').filter(Boolean);
-
-        if (filePaths.length === 0) {
-          return {
-            success: false,
-            error: 'No files were downloaded',
-            filePaths: [],
-          };
-        }
-
-        const mediaInfo = await this.getMediaInfo(url);
-        if (!mediaInfo) {
-          return {
-            success: false,
-            error: 'Failed to get media info',
-            filePaths: [],
-          };
-        }
-
-        return {
-          success: true,
-          filePaths,
-          mediaInfo,
-        };
+        return await this.getGalleryDlInfo(url);
       }
-
-      // For non-image sites, use yt-dlp
-      // Get available formats first
-      const formats = await this.getFormats(url);
-
-      // Select the best format that meets our criteria
-      const formatSpec = this.selectBestFormat(formats, options);
-
-      logger.info('Selected format spec', { command: 'download', formatSpec });
-
-      const outputTemplate = `${this.downloadPath}/%(title)s-%(id)s.%(ext)s`;
-
-      const command = [
-        'yt-dlp',
-        `--format ${shellEscape(formatSpec)}`,
-        '--no-playlist',
-        `--output ${shellEscape(outputTemplate)}`,
-        // Skip info extraction since we already have it
-        '--no-download-archive',
-        '--no-write-info-json',
-        '--no-write-description',
-        '--no-write-thumbnail',
-        '--no-progress',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      const { stdout, stderr } = await execAsync(command, { timeout: options.timeout * 1000 });
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'download', stderr });
-      }
-
-      // Extract file path from output
-      const filePath = this.extractFilePath(stdout);
-
-      if (!filePath) {
-        return {
-          success: false,
-          error: 'Failed to extract downloaded file path',
-          filePaths: [],
-        };
-      }
-
-      const mediaInfo = await this.getMediaInfo(url);
-      if (!mediaInfo) {
-        return {
-          success: false,
-          error: 'Failed to get media info',
-          filePaths: [],
-        };
-      }
-
-      return {
-        success: true,
-        filePaths: [filePath],
-        mediaInfo,
-      };
+      return await this.getYtDlpInfo(url);
     } catch (error) {
-      logger.error('Failed to download media', error);
+      logger.error('Failed to get media info', { error });
+      return null;
+    }
+  }
+
+  private async getGalleryDlInfo(url: string): Promise<MediaMetadata> {
+    const { stdout } = await safeExec('gallery-dl', ['-j', ...this.getCookieArgs(url), url]);
+
+    let output: Array<[unknown, unknown, MediaType?]>;
+    try {
+      output = JSON.parse(stdout);
+    } catch {
+      throw new Error('Failed to parse gallery-dl JSON output');
+    }
+
+    const postMetadata = (output[0]?.[1] ?? {}) as Record<string, unknown>;
+    const mediaTypes = output.slice(1).map((item) => {
+      const [, itemUrl, metadata] = item as [unknown, string, MediaType];
+      const { display_url, ...rest } = metadata;
+      return { ...rest, url: display_url || itemUrl };
+    });
+
+    const title =
+      (postMetadata.tweet_text as string) ||
+      (postMetadata.description as string) ||
+      (postMetadata.text as string) ||
+      (postMetadata.content as string) ||
+      'No title';
+
+    return {
+      url,
+      title,
+      format: 'image',
+      thumbnail: mediaTypes[0]?.url,
+      mediaTypes,
+    };
+  }
+
+  private async getYtDlpInfo(url: string): Promise<MediaMetadata> {
+    // Single yt-dlp call: get metadata + codec info to determine audio vs video
+    const printTemplate = [
+      '{',
+      '"url": %(url)j,',
+      '"title": %(title)j,',
+      '"duration": %(duration)s,',
+      '"thumbnail": %(thumbnail)j,',
+      '"vcodec": "%(vcodec)s",',
+      '"acodec": "%(acodec)s"',
+      '}',
+    ].join('');
+
+    const { stdout } = await withRetry(() =>
+      safeExec('yt-dlp', [
+        '--no-download',
+        '--print',
+        printTemplate,
+        '--no-playlist',
+        ...this.getCookieArgs(url),
+        url,
+      ]),
+    );
+
+    const cleanJson = stdout.replace(/: NA,/g, ': null,').replace(/: NA}/g, ': null}');
+
+    let info: Record<string, unknown>;
+    try {
+      info = JSON.parse(cleanJson);
+    } catch {
+      throw new Error('Failed to parse yt-dlp JSON output');
+    }
+
+    const vcodec = String(info.vcodec || '');
+    const hasVideo = vcodec !== '' && vcodec !== 'none' && vcodec !== 'null';
+
+    return {
+      url,
+      title: (info.title as string) || 'No title',
+      duration: info.duration ? Number(info.duration) : undefined,
+      format: hasVideo ? 'video' : 'audio',
+      thumbnail: info.thumbnail as string | undefined,
+    };
+  }
+
+  private getFormatSpec(format: string): string {
+    if (format === 'audio') return 'bestaudio[acodec=opus]/bestaudio';
+    if (format === 'image') return 'best[ext=jpg]/best[ext=png]/best[ext=webp]/best';
+    return 'best';
+  }
+
+  /**
+   * Downloads media from a URL. Accepts pre-fetched mediaInfo to avoid redundant calls.
+   */
+  public async download(
+    url: string,
+    options: DownloadOptions,
+    mediaInfo: MediaMetadata,
+  ): Promise<DownloadResult> {
+    try {
+      const filePaths = this.isImageSite(url)
+        ? await this.downloadWithGalleryDl(url, options)
+        : await this.downloadWithYtDlp(url, options);
+
+      if (filePaths.length === 0) {
+        return { success: false, error: 'No files were downloaded', filePaths: [] };
+      }
+
+      return { success: true, filePaths, mediaInfo };
+    } catch (error) {
+      logger.error('Failed to download media', { error });
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error occurred',
@@ -372,44 +193,83 @@ export class MediaDownloader {
     }
   }
 
-  /**
-   * Extracts file path from yt-dlp output
-   */
-  private extractFilePath(output: string): string | null {
-    // Split output into lines and reverse to get the most recent messages
-    const lines = output.split('\n').reverse();
+  private async downloadWithGalleryDl(url: string, options: DownloadOptions): Promise<string[]> {
+    const { stdout } = await safeExec(
+      'gallery-dl',
+      [
+        '--download-archive',
+        '/dev/null',
+        '--dest',
+        env.TMP_DIR,
+        '--filename',
+        '{filename}.{extension}',
+        '--no-mtime',
+        ...this.getCookieArgs(url),
+        url,
+      ],
+      { timeout: options.timeout },
+    );
 
+    const filePaths = stdout.trim().split('\n').filter(Boolean).slice(0, MAX_FILES_PER_DOWNLOAD);
+
+    return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
+  }
+
+  private async downloadWithYtDlp(url: string, options: DownloadOptions): Promise<string[]> {
+    const formatSpec = this.getFormatSpec(options.format);
+    const outputTemplate = `${env.TMP_DIR}/%(title)s-%(id)s.%(ext)s`;
+
+    const { stdout } = await safeExec(
+      'yt-dlp',
+      [
+        '--format',
+        formatSpec,
+        '--no-playlist',
+        '--output',
+        outputTemplate,
+        '--restrict-filenames',
+        '--no-download-archive',
+        '--no-write-info-json',
+        '--no-write-description',
+        '--no-write-thumbnail',
+        '--no-progress',
+        ...this.getCookieArgs(url),
+        url,
+      ],
+      { timeout: options.timeout },
+    );
+
+    const filePath = this.extractFilePath(stdout);
+    if (!filePath) return [];
+
+    return [assertSafePath(filePath, env.TMP_DIR)];
+  }
+
+  private extractFilePath(output: string): string | null {
+    const lines = output.split('\n').reverse();
     for (const line of lines) {
-      // Look for the final merged output for videos
       if (line.includes('[Merger] Merging formats into')) {
         const match = line.match(/Merging formats into "(.*?)"/);
         if (match) return match[1];
       }
-
-      // Look for the final audio extraction output
       if (line.includes('[ExtractAudio] Destination:')) {
         const match = line.match(/Destination: (.*)/);
         if (match) return match[1];
       }
-
-      // Look for direct download destination as fallback
       if (line.includes('[download] Destination:')) {
         const match = line.match(/Destination: (.*)/);
         if (match) return match[1];
       }
     }
-
     return null;
   }
 
-  /**
-   * Cleans up downloaded file
-   */
   public async cleanup(filePath: string): Promise<void> {
     try {
+      assertSafePath(filePath, env.TMP_DIR);
       await unlink(filePath);
     } catch {
-      // Ignore cleanup errors
+      // Ignore cleanup errors (file may already be deleted)
     }
   }
 }

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -1,6 +1,5 @@
 import { unlink } from 'fs/promises';
 import { env, getCookieFileForDomain } from '../config/env.js';
-import { withRetry } from '../utils/retry.js';
 import { safeExec } from '../utils/exec.js';
 import { assertSafePath } from '../utils/pathSafety.js';
 import { isDomainMatch } from '../utils/url.js';
@@ -67,7 +66,7 @@ export class MediaDownloader {
 
   /**
    * Gets media information without downloading.
-   * Throws on failure so withRetry can retry transient errors.
+   * Throws on failure so the caller's withRetry can handle retries.
    */
   public async getMediaInfo(url: string): Promise<MediaMetadata> {
     if (this.isImageSite(url)) {
@@ -79,15 +78,22 @@ export class MediaDownloader {
   private async getGalleryDlInfo(url: string): Promise<MediaMetadata> {
     const { stdout } = await safeExec('gallery-dl', ['-j', ...this.getCookieArgs(url), url]);
 
-    let output: Array<[unknown, unknown, MediaType?]>;
+    let output: unknown;
     try {
       output = JSON.parse(stdout);
     } catch {
       throw new Error('Failed to parse gallery-dl JSON output');
     }
 
+    if (!Array.isArray(output) || output.length === 0) {
+      throw new Error('Unexpected gallery-dl output structure: expected non-empty array');
+    }
+
     const postMetadata = (output[0]?.[1] ?? {}) as Record<string, unknown>;
-    const mediaTypes = output.slice(1).map((item) => {
+    const mediaTypes = output.slice(1).map((item: unknown[]) => {
+      if (!Array.isArray(item) || item.length < 3 || !item[2]) {
+        return { url: String(item?.[1] ?? '') };
+      }
       const [, itemUrl, metadata] = item as [unknown, string, MediaType];
       const { display_url, ...rest } = metadata;
       return { ...rest, url: display_url || itemUrl };
@@ -110,6 +116,7 @@ export class MediaDownloader {
   }
 
   private async getYtDlpInfo(url: string): Promise<MediaMetadata> {
+    // No inner withRetry — the caller owns retry responsibility
     const printTemplate = [
       '{',
       '"url": %(url)j,',
@@ -121,16 +128,14 @@ export class MediaDownloader {
       '}',
     ].join('');
 
-    const { stdout } = await withRetry(() =>
-      safeExec('yt-dlp', [
-        '--no-download',
-        '--print',
-        printTemplate,
-        '--no-playlist',
-        ...this.getCookieArgs(url),
-        url,
-      ]),
-    );
+    const { stdout } = await safeExec('yt-dlp', [
+      '--no-download',
+      '--print',
+      printTemplate,
+      '--no-playlist',
+      ...this.getCookieArgs(url),
+      url,
+    ]);
 
     const cleanJson = stdout.replace(/: NA,/g, ': null,').replace(/: NA}/g, ': null}');
 
@@ -161,7 +166,7 @@ export class MediaDownloader {
 
   /**
    * Downloads media from a URL. Accepts pre-fetched mediaInfo to avoid redundant calls.
-   * Throws on transient errors so withRetry can retry.
+   * Throws on transient errors so the caller's withRetry can retry.
    */
   public async download(
     url: string,
@@ -199,13 +204,14 @@ export class MediaDownloader {
     );
 
     const filePaths = stdout.trim().split('\n').filter(Boolean);
-    return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
+    return filePaths.map((p) => assertSafePath(p.trimEnd(), env.TMP_DIR));
   }
 
   private async downloadWithYtDlp(url: string, options: DownloadOptions): Promise<string[]> {
     const formatSpec = this.getFormatSpec(options.format);
     const outputTemplate = `${env.TMP_DIR}/%(title)s-%(id)s.%(ext)s`;
 
+    // Use --print after_move:filepath for reliable path extraction
     const { stdout } = await safeExec(
       'yt-dlp',
       [
@@ -217,40 +223,20 @@ export class MediaDownloader {
         '--restrict-filenames',
         '--max-filesize',
         String(options.maxFileSize),
-        '--no-download-archive',
-        '--no-write-info-json',
-        '--no-write-description',
-        '--no-write-thumbnail',
-        '--no-progress',
+        '--quiet',
+        '--no-warnings',
+        '--print',
+        'after_move:filepath',
         ...this.getCookieArgs(url),
         url,
       ],
       { timeout: options.timeout },
     );
 
-    const filePath = this.extractFilePath(stdout);
+    const filePath = stdout.trimEnd().split('\n').pop()?.trim();
     if (!filePath) return [];
 
     return [assertSafePath(filePath, env.TMP_DIR)];
-  }
-
-  private extractFilePath(output: string): string | null {
-    const lines = output.split('\n').reverse();
-    for (const line of lines) {
-      if (line.includes('[Merger] Merging formats into')) {
-        const match = line.match(/Merging formats into "(.*?)"/);
-        if (match) return match[1];
-      }
-      if (line.includes('[ExtractAudio] Destination:')) {
-        const match = line.match(/Destination: (.*)/);
-        if (match) return match[1];
-      }
-      if (line.includes('[download] Destination:')) {
-        const match = line.match(/Destination: (.*)/);
-        if (match) return match[1];
-      }
-    }
-    return null;
   }
 
   public async cleanup(filePath: string): Promise<void> {

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -1,48 +1,21 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { unlink } from 'fs/promises';
-import type { DownloadOptions, DownloadResult } from '../types/index.js';
+import { randomUUID } from 'node:crypto';
+import { env, findSiteByDomain, getCookieFileForDomain, getSiteHeaders } from '../config/env.js';
 import { logger } from '../utils/logger.js';
-import { withRetry } from '../utils/retry.js';
-import { getCookieFileForDomain } from '../config/env.js';
+import { safeExec } from '../utils/exec.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import { applyRateLimitFromError, isRateLimitError } from '../utils/hostCooldown.js';
+import type { DownloadOptions, DownloadResult } from '../types/index.js';
 
-const execAsync = promisify(exec);
-
-// Telegram limits (in bytes)
-const TELEGRAM_LIMITS = {
-  STANDARD: 50 * 1024 * 1024, // 50MB for regular bot API
-  LOCAL_SERVER: 2000 * 1024 * 1024, // 2GB with local bot API server
-} as const;
-
-/**
- * Escapes a string for shell usage
- */
-function shellEscape(str: string): string {
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
-
-interface FormatInfo {
-  id?: string;
-  ext?: string;
-  filesize?: number;
-  filesize_approx?: number;
-  vcodec?: string;
-  acodec?: string;
-  abr?: number;
-  tbr?: number;
-  format_id: string;
-}
-
-export interface MediaMetadata {
-  url: string;
-  title: string;
-  duration?: number;
-  format: 'audio' | 'video' | 'image';
-  thumbnail?: string;
-  formats?: FormatInfo[];
-  filesize?: number;
-  mediaTypes?: MediaType[];
-}
+const MAX_FILES_PER_DOWNLOAD = 100;
+// Metadata fetches should be quick; anything longer is effectively a hang
+// from the user's perspective. The retry layer handles transient failures.
+const INFO_FETCH_TIMEOUT_SEC = 15;
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mkv', 'mov', 'avi']);
+// Gallery-dl Python filter expression derived from the same set — single source of truth
+const GALLERY_DL_IMAGE_FILTER = `extension not in (${[...VIDEO_EXTENSIONS]
+  .map((e) => `'${e}'`)
+  .join(',')})`;
 
 interface MediaType {
   url: string;
@@ -50,16 +23,22 @@ interface MediaType {
   [key: string]: unknown;
 }
 
+export interface MediaMetadata {
+  url: string;
+  title: string;
+  duration?: number;
+  format: 'audio' | 'video' | 'image';
+  mediaTypes?: MediaType[];
+  contentCounts?: { images: number; videos: number };
+}
+
+/** Coerce an unknown JSON field (from external tool output) to a string. */
+const asString = (v: unknown): string => (typeof v === 'string' ? v : '');
+
 export class MediaDownloader {
   private static instance: MediaDownloader;
-  private downloadPath: string;
-  private maxFileSize: number;
 
-  private constructor() {
-    this.downloadPath = './tmp';
-    // Use standard limit by default
-    this.maxFileSize = TELEGRAM_LIMITS.STANDARD;
-  }
+  private constructor() {}
 
   public static getInstance(): MediaDownloader {
     if (!MediaDownloader.instance) {
@@ -68,348 +47,458 @@ export class MediaDownloader {
     return MediaDownloader.instance;
   }
 
-  private getYtDlpCookieArgs(url: string): string[] {
-    const args: string[] = [];
+  private getHostname(url: string): string | null {
     try {
-      // Extract domain from URL
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      const cookieFile = getCookieFileForDomain(domain);
-
-      if (cookieFile) {
-        args.push(`--cookies ${shellEscape(cookieFile)}`);
-      }
-    } catch (error) {
-      logger.warn('Failed to parse URL for cookie configuration', { url, error });
-    }
-    return args;
-  }
-
-  private getGalleryDlCookieArgs(url: string): string[] {
-    const args: string[] = [];
-    try {
-      // Extract domain from URL
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      const cookieFile = getCookieFileForDomain(domain);
-
-      if (cookieFile) {
-        args.push(`--cookies ${shellEscape(cookieFile)}`);
-      }
-    } catch (error) {
-      logger.warn('Failed to parse URL for cookie configuration', { url, error });
-    }
-    return args;
-  }
-
-  private isImageSite(url: string): boolean {
-    try {
-      const domain = new URL(url).hostname.replace(/^www\./, '');
-      return [
-        'instagram.com',
-        'twitter.com',
-        'x.com',
-        'pixiv.net',
-        'deviantart.com',
-        'artstation.com',
-      ].some((site) => domain.endsWith(site));
+      return new URL(url).hostname.replace(/^www\./, '');
     } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Gets media information without downloading
-   */
-  public async getMediaInfo(url: string): Promise<MediaMetadata | null> {
-    try {
-      if (this.isImageSite(url)) {
-        const command = [
-          'gallery-dl',
-          '-j',
-          ...this.getGalleryDlCookieArgs(url),
-          shellEscape(url),
-        ].join(' ');
-
-        const { stdout, stderr } = await execAsync(command);
-
-        if (stderr) {
-          logger.warn('gallery-dl warning', { command: 'getMediaInfo' });
-        }
-
-        const output = JSON.parse(stdout);
-        // First item contains post metadata
-        const postMetadata = output[0][1];
-        // Remaining items are media
-        const mediaTypes = output.slice(1).map((item: [unknown, string, MediaType]) => {
-          const [, itemUrl, metadata] = item;
-          const { display_url, ...rest } = metadata;
-          return {
-            ...rest,
-            url: display_url || itemUrl,
-          };
-        });
-
-        // Build title from available metadata
-        let title = '';
-        if (postMetadata.tweet_text) {
-          title = postMetadata.tweet_text;
-        } else if (postMetadata.description) {
-          title = postMetadata.description;
-        } else if (postMetadata.text) {
-          title = postMetadata.text;
-        } else if (postMetadata.content) {
-          title = postMetadata.content;
-        } else {
-          title = 'No title';
-        }
-
-        return {
-          url,
-          title,
-          format: 'image',
-          thumbnail: mediaTypes[0]?.display_url,
-          mediaTypes,
-        };
-      }
-
-      // If we get here, use yt-dlp for audio/video content
-      const printTemplate = [
-        '{',
-        '"url": %(url)j,',
-        '"title": %(title)j,',
-        '"duration": %(duration)s,',
-        '"thumbnail": %(thumbnail)j',
-        '}',
-      ].join('');
-
-      const command = [
-        'yt-dlp',
-        '--no-download',
-        `--print ${shellEscape(printTemplate)}`,
-        '--no-playlist',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      // Execute with retries
-      const { stdout, stderr } = await withRetry(() => execAsync(command));
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'getMediaInfo', stderr });
-      }
-
-      const cleanJson = stdout.replace(/: NA,/g, ': null,').replace(/: NA}/g, ': null}');
-      const info = JSON.parse(cleanJson);
-
-      // Get formats with retries only for video/audio content
-      const formats = await withRetry(() => this.getFormats(url));
-      const hasVideo = formats.some((f) => f.vcodec && f.vcodec !== 'none' && f.vcodec !== 'null');
-
-      return {
-        url,
-        title: info.title,
-        duration: info.duration ? Number(info.duration) : undefined,
-        format: hasVideo ? 'video' : 'audio',
-        thumbnail: info.thumbnail,
-        formats,
-      };
-    } catch (error) {
-      logger.error('Failed to get media info', error);
       return null;
     }
   }
 
-  private async getFormats(url: string): Promise<FormatInfo[]> {
-    try {
-      const command = [
-        'yt-dlp',
-        '--no-download',
-        '--print',
-        shellEscape('%(formats)j'),
-        '--no-playlist',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      const { stdout, stderr } = await execAsync(command);
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'getFormats' });
-      }
-
-      return JSON.parse(stdout);
-    } catch (error) {
-      logger.error('Failed to get formats', error);
-      return [];
+  /**
+   * All per-URL flags (cookies + browser fingerprint headers) for yt-dlp.
+   * Parses the hostname once. Helps keep sessions fresh by matching the
+   * browser fingerprint that exported the cookies.
+   */
+  private getYtDlpPerUrlArgs(url: string): string[] {
+    const domain = this.getHostname(url);
+    if (!domain) return [];
+    const cookieFile = getCookieFileForDomain(domain);
+    const headers = getSiteHeaders(domain);
+    const args: string[] = [];
+    for (const [name, value] of Object.entries(headers)) {
+      if (name === 'user-agent') args.push('--user-agent', value);
+      else args.push('--add-header', `${name}: ${value}`);
     }
-  }
-
-  private selectBestFormat(formats: FormatInfo[], options: DownloadOptions): string {
-    const formatSpec =
-      options.format === 'audio'
-        ? 'bestaudio[acodec=opus]/bestaudio'
-        : options.format === 'image'
-          ? 'best[ext=jpg]/best[ext=png]/best[ext=webp]/best'
-          : 'best';
-    logger.debug('Selected format spec', { command: 'selectBestFormat', formatSpec });
-    return formatSpec;
+    if (cookieFile) args.push('--cookies', cookieFile);
+    return args;
   }
 
   /**
-   * Downloads media from a given URL using yt-dlp
+   * All per-URL flags (cookies + headers) for gallery-dl via -o extractor.<site>.*
+   * Values are JSON-encoded so gallery-dl's parser treats them as strings
+   * (e.g. "936619743392459" stays a string; values with embedded quotes
+   * like Sec-CH-UA get proper escaping).
+   *
+   * Instagram-specific flags address the Apr-2026 429 wave on the
+   * `/api/v1/users/web_profile_info/` endpoint: user-cache + user-strategy=id
+   * skip the throttled username→id lookup; sleep-request adds the documented
+   * default spacing between Instagram API calls.
    */
-  public async download(url: string, options: DownloadOptions): Promise<DownloadResult> {
+  private getGalleryDlPerUrlArgs(url: string): string[] {
+    const domain = this.getHostname(url);
+    if (!domain) return [];
+    const site = findSiteByDomain(domain);
+    const cookieFile = getCookieFileForDomain(domain);
+    const args: string[] = [];
+    if (site) {
+      const headers = getSiteHeaders(domain);
+      for (const [name, value] of Object.entries(headers)) {
+        const encoded = JSON.stringify(value);
+        if (name === 'user-agent') {
+          args.push('-o', `extractor.${site.alias}.user-agent=${encoded}`);
+        } else {
+          args.push('-o', `extractor.${site.alias}.headers.${name}=${encoded}`);
+        }
+      }
+      if (site.alias === 'instagram') {
+        args.push(
+          '-o',
+          'extractor.instagram.user-cache=true',
+          '-o',
+          'extractor.instagram.user-strategy="id"',
+          '-o',
+          'extractor.instagram.sleep-request="6.0-12.0"',
+        );
+      }
+    }
+    if (cookieFile) args.push('--cookies', cookieFile);
+    return args;
+  }
+
+  private isImageSite(url: string): boolean {
+    const domain = this.getHostname(url);
+    if (!domain) return false;
+    return findSiteByDomain(domain)?.type === 'image';
+  }
+
+  /**
+   * Gets media information without downloading.
+   * Throws on failure so the caller's withRetry can handle retries.
+   */
+  public async getMediaInfo(url: string): Promise<MediaMetadata> {
+    if (this.isImageSite(url)) {
+      return await this.getGalleryDlInfo(url);
+    }
+    return await this.getYtDlpInfo(url);
+  }
+
+  private async getGalleryDlInfo(url: string): Promise<MediaMetadata> {
+    let stdout: string;
     try {
-      if (this.isImageSite(url)) {
-        const command = [
-          'gallery-dl',
+      // --retries 0: bail immediately on 429 instead of letting gallery-dl
+      // burn our 15s budget on internal back-off. The host-cooldown layer
+      // (set in catch below) prevents future requests until it's safe.
+      const result = await safeExec(
+        'gallery-dl',
+        ['--retries', '0', '-j', ...this.getGalleryDlPerUrlArgs(url), url],
+        { timeout: INFO_FETCH_TIMEOUT_SEC },
+      );
+      stdout = result.stdout;
+    } catch (error) {
+      if (isRateLimitError(error)) {
+        const host = this.getHostname(url);
+        const message = error instanceof Error ? error.message : String(error);
+        if (host) applyRateLimitFromError(host, message);
+      }
+      throw error;
+    }
+
+    let output: unknown;
+    try {
+      output = JSON.parse(stdout);
+    } catch {
+      throw new Error('Failed to parse gallery-dl JSON output');
+    }
+
+    if (!Array.isArray(output) || output.length === 0) {
+      throw new Error('Unexpected gallery-dl output structure: expected non-empty array');
+    }
+
+    const postMetadata = (output[0]?.[1] ?? {}) as Record<string, unknown>;
+    const mediaTypes = output.slice(1).map((item: unknown[]) => {
+      if (!Array.isArray(item) || item.length < 3 || !item[2]) {
+        return { url: String(item?.[1] ?? '') };
+      }
+      const [, itemUrl, metadata] = item as [unknown, string, MediaType];
+      const { display_url, ...rest } = metadata;
+      return { ...rest, url: asString(display_url) || itemUrl };
+    });
+
+    const title =
+      asString(postMetadata.tweet_text) ||
+      asString(postMetadata.description) ||
+      asString(postMetadata.text) ||
+      asString(postMetadata.content) ||
+      'No title';
+
+    const imageCount = mediaTypes.filter(
+      (m) =>
+        !VIDEO_EXTENSIONS.has(String((m as Record<string, unknown>).extension || '').toLowerCase()),
+    ).length;
+    const videoCount = mediaTypes.filter((m) =>
+      VIDEO_EXTENSIONS.has(String((m as Record<string, unknown>).extension || '').toLowerCase()),
+    ).length;
+
+    return {
+      url,
+      title,
+      format: videoCount > 0 ? 'video' : 'image',
+      mediaTypes,
+      contentCounts: { images: imageCount, videos: videoCount },
+    };
+  }
+
+  private async getYtDlpInfo(url: string): Promise<MediaMetadata> {
+    // No inner withRetry — the caller owns retry responsibility
+    const printTemplate = [
+      '{',
+      '"title": %(title)j,',
+      '"duration": %(duration)s,',
+      '"vcodec": %(vcodec)j,',
+      '"acodec": %(acodec)j',
+      '}',
+    ].join('');
+
+    let stdout: string;
+    try {
+      // --retries 0 / --extractor-retries 0: same fast-fail rationale as
+      // getGalleryDlInfo — let host-cooldown own 429 backoff, not yt-dlp.
+      const result = await safeExec(
+        'yt-dlp',
+        [
+          '--no-download',
+          '--print',
+          printTemplate,
+          '--no-playlist',
+          '--retries',
+          '0',
+          '--extractor-retries',
+          '0',
+          ...this.getYtDlpPerUrlArgs(url),
+          url,
+        ],
+        { timeout: INFO_FETCH_TIMEOUT_SEC },
+      );
+      stdout = result.stdout;
+    } catch (error) {
+      if (isRateLimitError(error)) {
+        const host = this.getHostname(url);
+        const message = error instanceof Error ? error.message : String(error);
+        if (host) applyRateLimitFromError(host, message);
+      }
+      throw error;
+    }
+
+    // yt-dlp emits a bare NA (not "NA" or null) for any unavailable field —
+    // %(...)s always, and %(...)j when the value is absent — so normalize every
+    // bare NA value to null before parsing (e.g. vcodec/acodec on some sites).
+    const cleanJson = stdout.replace(/: NA(?=[,}])/g, ': null');
+
+    let info: Record<string, unknown>;
+    try {
+      info = JSON.parse(cleanJson);
+    } catch {
+      throw new Error('Failed to parse yt-dlp JSON output');
+    }
+
+    const vcodec = String(info.vcodec || '');
+    const hasVideo = vcodec !== '' && vcodec !== 'none' && vcodec !== 'null';
+
+    return {
+      url,
+      title: asString(info.title) || 'No title',
+      duration: info.duration != null ? Number(info.duration) : undefined,
+      format: hasVideo ? 'video' : 'audio',
+    };
+  }
+
+  private getFormatSpec(format: string, maxFileSize: number): string {
+    if (format === 'audio') return 'bestaudio[acodec=opus]/bestaudio';
+    if (format === 'image') return 'best[ext=jpg]/best[ext=png]/best[ext=webp]/best';
+    // Prefer H.264 video + AAC audio under the size cap (Telegram plays these
+    // inline), then fall back to the size-filtered DASH chain, then anything.
+    // bv (not bv*) keeps the size filter meaningful — pre-merged blobs lack filesize.
+    return (
+      `bv*[vcodec^=avc1][filesize<${maxFileSize}]+ba[acodec^=mp4a]/` +
+      `bv[filesize<${maxFileSize}]+ba/bv[filesize_approx<${maxFileSize}]+ba/bv+ba/b`
+    );
+  }
+
+  /**
+   * Downloads media from a URL. Accepts pre-fetched mediaInfo to avoid redundant calls.
+   * Throws on transient errors so the caller's withRetry can retry.
+   */
+  public async download(
+    url: string,
+    options: DownloadOptions,
+    mediaInfo: MediaMetadata,
+  ): Promise<DownloadResult> {
+    let filePaths: string[];
+
+    if (this.isImageSite(url)) {
+      const { images = 0, videos = 0 } = mediaInfo.contentCounts || {};
+      const written: string[] = [];
+      try {
+        if (images > 0) written.push(...(await this.downloadImagesWithGalleryDl(url, options)));
+      } catch (error) {
+        // Images are the primary content for image sites — a failure here is fatal.
+        await Promise.all(written.map((p) => this.cleanup(p)));
+        throw error;
+      }
+      if (videos > 0) {
+        try {
+          written.push(...(await this.downloadVideosWithYtDlp(url, options)));
+        } catch (error) {
+          // Videos totally failed. If we already have images, deliver those
+          // rather than discarding a valid partial result; otherwise rethrow.
+          if (written.length === 0) throw error;
+          logger.warn('Carousel videos failed; delivering images only', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      filePaths = written;
+    } else {
+      filePaths = await this.downloadWithYtDlp(url, options);
+    }
+
+    if (filePaths.length === 0) {
+      return { success: false, error: 'No files were downloaded', filePaths: [] };
+    }
+
+    return { success: true, filePaths, mediaInfo };
+  }
+
+  private async downloadImagesWithGalleryDl(
+    url: string,
+    options: DownloadOptions,
+  ): Promise<string[]> {
+    // Per-request filename prefix so two concurrent DISTINCT URLs whose media
+    // share a native filename can't collide/overwrite in the flat TMP_DIR.
+    const prefix = randomUUID().slice(0, 8);
+    let stdout: string;
+    try {
+      ({ stdout } = await safeExec(
+        'gallery-dl',
+        [
           '--download-archive',
           '/dev/null',
           '--dest',
-          `'${this.downloadPath}'`,
+          env.TMP_DIR,
           '--filename',
-          '{filename}.{extension}',
+          `${prefix}_{filename}.{extension}`,
           '--no-mtime',
-          ...this.getGalleryDlCookieArgs(url),
-          shellEscape(url),
-        ].join(' ');
-
-        const { stdout, stderr } = await execAsync(command, { timeout: options.timeout * 1000 });
-
-        if (stderr && !stderr.includes('Failed to open download archive')) {
-          logger.warn('gallery-dl warning', { command: 'download' });
-        }
-
-        const filePaths = stdout.trim().split('\n').filter(Boolean);
-
-        if (filePaths.length === 0) {
-          return {
-            success: false,
-            error: 'No files were downloaded',
-            filePaths: [],
-          };
-        }
-
-        const mediaInfo = await this.getMediaInfo(url);
-        if (!mediaInfo) {
-          return {
-            success: false,
-            error: 'Failed to get media info',
-            filePaths: [],
-          };
-        }
-
-        return {
-          success: true,
-          filePaths,
-          mediaInfo,
-        };
-      }
-
-      // For non-image sites, use yt-dlp
-      // Get available formats first
-      const formats = await this.getFormats(url);
-
-      // Select the best format that meets our criteria
-      const formatSpec = this.selectBestFormat(formats, options);
-
-      logger.info('Selected format spec', { command: 'download', formatSpec });
-
-      const outputTemplate = `${this.downloadPath}/%(title)s-%(id)s.%(ext)s`;
-
-      const command = [
-        'yt-dlp',
-        `--format ${shellEscape(formatSpec)}`,
-        '--no-playlist',
-        `--output ${shellEscape(outputTemplate)}`,
-        // Skip info extraction since we already have it
-        '--no-download-archive',
-        '--no-write-info-json',
-        '--no-write-description',
-        '--no-write-thumbnail',
-        '--no-progress',
-        ...this.getYtDlpCookieArgs(url),
-        shellEscape(url),
-      ].join(' ');
-
-      const { stdout, stderr } = await execAsync(command, { timeout: options.timeout * 1000 });
-
-      if (stderr) {
-        logger.warn('yt-dlp warning', { command: 'download', stderr });
-      }
-
-      // Extract file path from output
-      const filePath = this.extractFilePath(stdout);
-
-      if (!filePath) {
-        return {
-          success: false,
-          error: 'Failed to extract downloaded file path',
-          filePaths: [],
-        };
-      }
-
-      const mediaInfo = await this.getMediaInfo(url);
-      if (!mediaInfo) {
-        return {
-          success: false,
-          error: 'Failed to get media info',
-          filePaths: [],
-        };
-      }
-
-      return {
-        success: true,
-        filePaths: [filePath],
-        mediaInfo,
-      };
+          '--filter',
+          GALLERY_DL_IMAGE_FILTER,
+          '--range',
+          `1-${MAX_FILES_PER_DOWNLOAD}`,
+          ...this.getGalleryDlPerUrlArgs(url),
+          url,
+        ],
+        { timeout: options.timeout },
+      ));
     } catch (error) {
-      logger.error('Failed to download media', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Unknown error occurred',
-        filePaths: [],
-      };
-    }
-  }
-
-  /**
-   * Extracts file path from yt-dlp output
-   */
-  private extractFilePath(output: string): string | null {
-    // Split output into lines and reverse to get the most recent messages
-    const lines = output.split('\n').reverse();
-
-    for (const line of lines) {
-      // Look for the final merged output for videos
-      if (line.includes('[Merger] Merging formats into')) {
-        const match = line.match(/Merging formats into "(.*?)"/);
-        if (match) return match[1];
+      // A 429 during the actual download must arm host-cooldown too (not just
+      // the info fetch), so the next request short-circuits instead of retrying.
+      if (isRateLimitError(error)) {
+        const host = this.getHostname(url);
+        if (host) {
+          applyRateLimitFromError(host, error instanceof Error ? error.message : String(error));
+        }
       }
-
-      // Look for the final audio extraction output
-      if (line.includes('[ExtractAudio] Destination:')) {
-        const match = line.match(/Destination: (.*)/);
-        if (match) return match[1];
-      }
-
-      // Look for direct download destination as fallback
-      if (line.includes('[download] Destination:')) {
-        const match = line.match(/Destination: (.*)/);
-        if (match) return match[1];
-      }
+      throw error;
     }
 
-    return null;
+    const filePaths = stdout
+      .trim()
+      .split('\n')
+      .map((p) => p.trim())
+      .filter((p) => p && !p.startsWith('#'));
+    return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
   }
 
-  /**
-   * Cleans up downloaded file
-   */
+  private async downloadVideosWithYtDlp(url: string, options: DownloadOptions): Promise<string[]> {
+    const formatSpec = this.getFormatSpec('video', options.maxFileSize);
+    const outputTemplate = `${env.TMP_DIR}/%(title)s-%(id)s.%(ext)s`;
+
+    // --ignore-errors: skip image items in carousels (yt-dlp can't handle images)
+    // No --no-playlist: process all video items in a carousel
+    // yt-dlp exits non-zero if ANY item fails, even with --ignore-errors,
+    // so catch the error and extract stdout for successfully downloaded paths
+    let stdout = '';
+    try {
+      const result = await safeExec(
+        'yt-dlp',
+        [
+          '--format',
+          formatSpec,
+          '--ignore-errors',
+          '--output',
+          outputTemplate,
+          '--restrict-filenames',
+          '--no-mtime',
+          '--merge-output-format',
+          'mp4',
+          '--write-thumbnail',
+          '--convert-thumbnails',
+          'jpg',
+          '--quiet',
+          '--no-warnings',
+          '--print',
+          'after_move:filepath',
+          ...this.getYtDlpPerUrlArgs(url),
+          url,
+        ],
+        { timeout: options.timeout },
+      );
+      stdout = result.stdout;
+    } catch (error) {
+      // Extract stdout — successful items still printed paths even on non-zero exit.
+      // Log so genuine failures (network, disk, invalid format) remain visible
+      // instead of being silently absorbed.
+      const hasStdout = (e: unknown): e is { stdout: string } =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as { stdout?: unknown }).stdout === 'string';
+      const hasStderr = (e: unknown): e is { stderr: string } =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as { stderr?: unknown }).stderr === 'string';
+      stdout = hasStdout(error) ? error.stdout : '';
+      logger.warn('yt-dlp exited non-zero during carousel download', {
+        stderr: hasStderr(error) ? error.stderr.slice(0, 500) : undefined,
+        message: error instanceof Error ? error.message : String(error),
+        gotPaths: stdout.trim().length > 0,
+      });
+      // Arm host-cooldown on any 429 — even a partial carousel (some items
+      // recovered) means the host is rate-limiting, so the next request should
+      // wait rather than retry immediately.
+      if (isRateLimitError(error)) {
+        const host = this.getHostname(url);
+        if (host) {
+          applyRateLimitFromError(host, error instanceof Error ? error.message : String(error));
+        }
+      }
+      // Nothing recovered → genuine total failure. Surface it so withRetry can
+      // retry; a swallowed error would otherwise be cached and sent as empty success.
+      if (stdout.trim().length === 0) throw error;
+    }
+
+    const filePaths = stdout
+      .trimEnd()
+      .split('\n')
+      .map((p) => p.trim())
+      .filter(Boolean);
+    return filePaths.map((p) => assertSafePath(p, env.TMP_DIR));
+  }
+
+  private async downloadWithYtDlp(url: string, options: DownloadOptions): Promise<string[]> {
+    const formatSpec = this.getFormatSpec(options.format, options.maxFileSize);
+    const outputTemplate = `${env.TMP_DIR}/%(title)s-%(id)s.%(ext)s`;
+    // Write per-video thumbnail to disk for video format so buildMediaItems
+    // can read it without an extra HTTP round-trip. Audio/image formats don't
+    // use thumbnails (replyWithVoice/replyWithPhoto don't accept them).
+    const videoArgs =
+      options.format === 'video'
+        ? ['--merge-output-format', 'mp4', '--write-thumbnail', '--convert-thumbnails', 'jpg']
+        : [];
+
+    let stdout: string;
+    try {
+      ({ stdout } = await safeExec(
+        'yt-dlp',
+        [
+          '--format',
+          formatSpec,
+          '--no-playlist',
+          '--output',
+          outputTemplate,
+          '--restrict-filenames',
+          '--no-mtime',
+          ...videoArgs,
+          '--quiet',
+          '--no-warnings',
+          '--print',
+          'after_move:filepath',
+          ...this.getYtDlpPerUrlArgs(url),
+          url,
+        ],
+        { timeout: options.timeout },
+      ));
+    } catch (error) {
+      // A 429 during the actual download must arm host-cooldown too.
+      if (isRateLimitError(error)) {
+        const host = this.getHostname(url);
+        if (host) {
+          applyRateLimitFromError(host, error instanceof Error ? error.message : String(error));
+        }
+      }
+      throw error;
+    }
+
+    const filePath = stdout.trimEnd().split('\n').pop()?.trim();
+    if (!filePath) return [];
+
+    return [assertSafePath(filePath, env.TMP_DIR)];
+  }
+
   public async cleanup(filePath: string): Promise<void> {
     try {
+      assertSafePath(filePath, env.TMP_DIR);
       await unlink(filePath);
     } catch {
-      // Ignore cleanup errors
+      // Ignore cleanup errors (file may already be deleted)
     }
   }
 }

--- a/src/services/mediaProbe.ts
+++ b/src/services/mediaProbe.ts
@@ -1,0 +1,111 @@
+import { readFile, stat, unlink } from 'fs/promises';
+import { safeExec } from '../utils/exec.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import { env } from '../config/env.js';
+
+const THUMBNAIL_MAX_BYTES = 200 * 1024;
+
+export interface FFprobeStream {
+  codec_type: string;
+  codec_name: string;
+  width?: number;
+  height?: number;
+  sample_rate?: string;
+  bit_rate?: string;
+}
+
+export interface FFprobeData {
+  streams: FFprobeStream[];
+  format?: { size?: string; bit_rate?: string };
+}
+
+export async function probeMediaFile(path: string): Promise<FFprobeData> {
+  const { stdout } = await safeExec('ffprobe', [
+    '-v',
+    'quiet',
+    '-print_format',
+    'json',
+    '-show_format',
+    '-show_streams',
+    path,
+  ]);
+  try {
+    return JSON.parse(stdout) as FFprobeData;
+  } catch {
+    throw new Error(`Failed to parse ffprobe output for ${path}`);
+  }
+}
+
+export async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
+  const thumbnailPath = `${videoPath}.thumb.jpg`;
+  assertSafePath(thumbnailPath, env.TMP_DIR);
+  try {
+    await safeExec('ffmpeg', [
+      '-y',
+      '-i',
+      videoPath,
+      '-vf',
+      "scale='min(320,iw)':'min(320,ih)':force_original_aspect_ratio=decrease",
+      '-q:v',
+      '6',
+      '-frames:v',
+      '1',
+      thumbnailPath,
+    ]);
+    const stats = await stat(thumbnailPath);
+    if (stats.size === 0 || stats.size > THUMBNAIL_MAX_BYTES) {
+      await unlink(thumbnailPath).catch(() => {});
+      return null;
+    }
+    const data = await readFile(thumbnailPath);
+    await unlink(thumbnailPath).catch(() => {});
+    return data;
+  } catch {
+    await unlink(thumbnailPath).catch(() => {});
+    return null;
+  }
+}
+
+function parseBitrate(raw: string | undefined): string {
+  if (!raw) return '';
+  const val = parseInt(raw, 10);
+  if (!Number.isFinite(val) || val <= 0) return '';
+  return `${Math.round(val / 1000)}kbps`;
+}
+
+function parseSampleRate(raw: string | undefined): string {
+  if (!raw) return '';
+  const val = parseInt(raw, 10);
+  if (!Number.isFinite(val) || val <= 0) return '';
+  return `${Math.round(val / 1000)}kHz`;
+}
+
+export function extractStreamInfo(
+  streams: FFprobeStream[],
+  isVideo: boolean,
+  format?: FFprobeData['format'],
+): { info: string; width?: number; height?: number } {
+  const videoStream = streams.find((s) => s.codec_type === 'video');
+  const width = videoStream?.width;
+  const height = videoStream?.height;
+
+  const parts = streams
+    .map((stream) => {
+      if (stream.codec_type === 'video') {
+        const dims = `${stream.width ?? '?'}x${stream.height ?? '?'}`;
+        if (!isVideo) return `${stream.codec_name} ${dims}`;
+        const bitrate = parseBitrate(stream.bit_rate) || parseBitrate(format?.bit_rate);
+        return `${stream.codec_name} ${dims}${bitrate ? ` ${bitrate}` : ''}`;
+      }
+      if (stream.codec_type === 'audio') {
+        const bitrate = parseBitrate(stream.bit_rate) || parseBitrate(format?.bit_rate);
+        const sampleRate = parseSampleRate(stream.sample_rate);
+        return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .join(', ');
+
+  return { info: parts, width, height };
+}

--- a/src/services/mediaProbe.ts
+++ b/src/services/mediaProbe.ts
@@ -20,6 +20,7 @@ export interface FFprobeData {
 }
 
 export async function probeMediaFile(path: string): Promise<FFprobeData> {
+  assertSafePath(path, env.TMP_DIR);
   const { stdout } = await safeExec('ffprobe', [
     '-v',
     'quiet',
@@ -37,6 +38,7 @@ export async function probeMediaFile(path: string): Promise<FFprobeData> {
 }
 
 export async function generateThumbnail(videoPath: string): Promise<Buffer | null> {
+  assertSafePath(videoPath, env.TMP_DIR);
   const thumbnailPath = `${videoPath}.thumb.jpg`;
   assertSafePath(thumbnailPath, env.TMP_DIR);
   try {

--- a/src/services/mediaProbe.ts
+++ b/src/services/mediaProbe.ts
@@ -98,7 +98,8 @@ export function extractStreamInfo(
         return `${stream.codec_name} ${dims}${bitrate ? ` ${bitrate}` : ''}`;
       }
       if (stream.codec_type === 'audio') {
-        const bitrate = parseBitrate(stream.bit_rate) || parseBitrate(format?.bit_rate);
+        // No format-level bitrate fallback for audio — it would duplicate the container bitrate
+        const bitrate = parseBitrate(stream.bit_rate);
         const sampleRate = parseSampleRate(stream.sample_rate);
         return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
       }

--- a/src/services/mediaProbe.ts
+++ b/src/services/mediaProbe.ts
@@ -1,0 +1,130 @@
+import { rename, unlink, stat } from 'node:fs/promises';
+import { safeExec } from '../utils/exec.js';
+import { assertSafePath } from '../utils/pathSafety.js';
+import { env } from '../config/env.js';
+
+// Telegram video thumbnails must be JPEG, ≤320px per side, and <200KB.
+const TELEGRAM_THUMB_MAX_DIM = 320;
+const TELEGRAM_THUMB_MAX_BYTES = 200 * 1024;
+
+export interface FFprobeStream {
+  codec_type: string;
+  codec_name: string;
+  width?: number;
+  height?: number;
+  sample_rate?: string;
+  bit_rate?: string;
+}
+
+export interface FFprobeData {
+  streams: FFprobeStream[];
+  format?: { size?: string; bit_rate?: string };
+}
+
+export async function probeMediaFile(path: string): Promise<FFprobeData> {
+  assertSafePath(path, env.TMP_DIR);
+  const { stdout } = await safeExec(
+    'ffprobe',
+    ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', path],
+    { timeout: 10 },
+  );
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !Array.isArray((parsed as { streams?: unknown }).streams)
+    ) {
+      throw new Error('ffprobe output missing a streams array');
+    }
+    return parsed as FFprobeData;
+  } catch {
+    throw new Error(`Failed to parse ffprobe output for ${path}`);
+  }
+}
+
+function parseBitrate(raw: string | undefined): string {
+  if (!raw) return '';
+  const val = parseInt(raw, 10);
+  if (!Number.isFinite(val) || val <= 0) return '';
+  return `${Math.round(val / 1000)}kbps`;
+}
+
+function parseSampleRate(raw: string | undefined): string {
+  if (!raw) return '';
+  const val = parseInt(raw, 10);
+  if (!Number.isFinite(val) || val <= 0) return '';
+  return `${Math.round(val / 1000)}kHz`;
+}
+
+export function extractStreamInfo(
+  streams: FFprobeStream[],
+  isVideo: boolean,
+  format?: FFprobeData['format'],
+): { info: string; width?: number; height?: number } {
+  const videoStream = streams.find((s) => s.codec_type === 'video');
+  const width = videoStream?.width;
+  const height = videoStream?.height;
+
+  const parts = streams
+    .map((stream) => {
+      if (stream.codec_type === 'video') {
+        const dims = `${stream.width ?? '?'}x${stream.height ?? '?'}`;
+        if (!isVideo) return `${stream.codec_name} ${dims}`;
+        const bitrate = parseBitrate(stream.bit_rate) || parseBitrate(format?.bit_rate);
+        return `${stream.codec_name} ${dims}${bitrate ? ` ${bitrate}` : ''}`;
+      }
+      if (stream.codec_type === 'audio') {
+        // No format-level bitrate fallback for audio — it would duplicate the container bitrate
+        const bitrate = parseBitrate(stream.bit_rate);
+        const sampleRate = parseSampleRate(stream.sample_rate);
+        return `${stream.codec_name}${bitrate ? ` ${bitrate}` : ''}${sampleRate ? ` ${sampleRate}` : ''}`;
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .join(', ');
+
+  return { info: parts, width, height };
+}
+
+/**
+ * Downscales a thumbnail in place to fit Telegram's ≤320px/<200KB JPEG limit
+ * (yt-dlp's --convert-thumbnails makes it JPEG but does not constrain size, and
+ * an oversized thumbnail can make the whole video send fail). Returns false —
+ * caller should omit the thumbnail and let Telegram auto-generate — if it fails.
+ */
+export async function scaleThumbnail(path: string): Promise<boolean> {
+  assertSafePath(path, env.TMP_DIR);
+  const scaled = `${path}.scaled.jpg`;
+  assertSafePath(scaled, env.TMP_DIR);
+  try {
+    await safeExec(
+      'ffmpeg',
+      [
+        '-y',
+        '-nostdin',
+        '-i',
+        path,
+        '-vf',
+        `scale='min(${TELEGRAM_THUMB_MAX_DIM},iw)':'min(${TELEGRAM_THUMB_MAX_DIM},ih)':force_original_aspect_ratio=decrease`,
+        '-frames:v',
+        '1',
+        scaled,
+      ],
+      { timeout: 15 },
+    );
+    // ≤320px JPEG is normally well under 200KB, but verify so a dense thumbnail
+    // can't still exceed Telegram's limit and fail the video send.
+    const { size } = await stat(scaled);
+    if (size > TELEGRAM_THUMB_MAX_BYTES) {
+      await unlink(scaled).catch(() => {});
+      return false;
+    }
+    await rename(scaled, path);
+    return true;
+  } catch {
+    await unlink(scaled).catch(() => {});
+    return false;
+  }
+}

--- a/src/services/versionCheck.ts
+++ b/src/services/versionCheck.ts
@@ -1,0 +1,108 @@
+import { safeExec } from '../utils/exec.js';
+import { logger } from '../utils/logger.js';
+
+interface ToolSpec {
+  readonly name: string;
+  readonly binary: string;
+  readonly pypiPackage: string;
+}
+
+const TOOLS: readonly ToolSpec[] = [
+  { name: 'gallery-dl', binary: 'gallery-dl', pypiPackage: 'gallery-dl' },
+  { name: 'yt-dlp', binary: 'yt-dlp', pypiPackage: 'yt-dlp' },
+];
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+async function getInstalledVersion(binary: string): Promise<string | null> {
+  try {
+    const { stdout } = await safeExec(binary, ['--version'], { timeout: 10 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function getLatestPypiVersion(packageName: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://pypi.org/pypi/${packageName}/json`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { info?: { version?: string } };
+    return data.info?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compares dot-separated CalVer/SemVer numerically, ignoring trailing
+ * non-numeric segments (e.g. ".dev0"). Returns >0 if a > b, <0 if a < b, 0 if equal.
+ * Handles yt-dlp's mixed leading-zero / dev-snapshot quirks correctly:
+ * "2026.04.10.235301" > "2026.3.17" because component 1 (04 vs 3) goes 4 > 3.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v
+      .split(/[.+-]/)
+      .map((p) => Number.parseInt(p, 10))
+      .filter((n) => Number.isFinite(n));
+  const aa = parse(a);
+  const bb = parse(b);
+  const len = Math.max(aa.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    const av = aa[i] ?? 0;
+    const bv = bb[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
+}
+
+async function checkOnce(): Promise<void> {
+  for (const tool of TOOLS) {
+    const [installed, latest] = await Promise.all([
+      getInstalledVersion(tool.binary),
+      getLatestPypiVersion(tool.pypiPackage),
+    ]);
+    if (!installed || !latest) {
+      logger.debug(
+        `Version check skipped for ${tool.name} (installed=${installed ?? 'unknown'}, latest=${latest ?? 'unknown'})`,
+      );
+      continue;
+    }
+    const cmp = compareVersions(installed, latest);
+    if (cmp >= 0) {
+      // Installed is current or newer (e.g. dev snapshot ahead of latest stable).
+      logger.info(`${tool.name} ${installed} is up to date (PyPI latest ${latest})`);
+    } else {
+      logger.warn(`${tool.name} ${installed} is outdated — latest is ${latest}`);
+    }
+  }
+}
+
+let timer: NodeJS.Timeout | null = null;
+
+/**
+ * Async runtime check that compares installed gallery-dl / yt-dlp versions
+ * against PyPI's latest. Runs once at startup, then every 24h. Failures
+ * (network, missing binary) are logged at debug level and never crash the
+ * bot — this is purely a freshness signal.
+ */
+export function startVersionCheck(): void {
+  if (timer) return; // idempotent: a second call must not orphan the existing interval
+  void checkOnce().catch((error) => logger.debug('Version check failed', { error }));
+  timer = setInterval(() => {
+    void checkOnce().catch((error) => logger.debug('Periodic version check failed', { error }));
+  }, CHECK_INTERVAL_MS);
+  timer.unref();
+}
+
+export function stopVersionCheck(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,5 @@
 import type { MediaMetadata } from '../services/downloader.js';
 
-export interface MediaInfo {
-  url: string;
-  title: string;
-  duration?: number;
-  filesize?: number;
-  format: 'audio' | 'video' | 'image';
-  thumbnail?: string;
-}
-
 export interface DownloadOptions {
   maxFileSize: number;
   timeout: number;
@@ -17,7 +8,7 @@ export interface DownloadOptions {
 
 export interface DownloadResult {
   success: boolean;
-  filePaths: string[]; // Array of paths, can contain one or more files
+  filePaths: string[];
   error?: string;
   mediaInfo?: MediaMetadata;
 }

--- a/src/utils/caption.ts
+++ b/src/utils/caption.ts
@@ -37,7 +37,7 @@ export function buildGroupCaption(
       const existing = imageFormats.get(key) || { count: 0, codec, dims };
       imageFormats.set(key, { ...existing, count: existing.count + 1 });
     }
-    chunkTotalSize += parseFloat(item.fileSizeMB);
+    chunkTotalSize += parseFloat(item.fileSizeMB) || 0;
   }
 
   const formatParts: string[] = [];

--- a/src/utils/caption.ts
+++ b/src/utils/caption.ts
@@ -1,0 +1,67 @@
+import { escapeMarkdownV2, escapeMarkdownV2Url, normalizeLineBreaks } from './markdown.js';
+
+export interface CaptionMediaItem {
+  isVideo: boolean;
+  streamInfo: string;
+  fileSizeMB: string;
+}
+
+export function buildSingleCaption(title: string, url: string, item: CaptionMediaItem): string {
+  const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
+  const escapedUrl = escapeMarkdownV2Url(url);
+  const escapedInfo = escapeMarkdownV2(item.streamInfo);
+  const escapedSize = escapeMarkdownV2(item.fileSizeMB);
+  return `[${escapedTitle}](${escapedUrl})\n\`${escapedInfo}, ${escapedSize}MB\``;
+}
+
+export function buildGroupCaption(
+  title: string,
+  url: string,
+  chunk: CaptionMediaItem[],
+  isFirstChunk: boolean,
+): string {
+  const imageFormats = new Map<string, { count: number; codec: string; dims: string }>();
+  const videoFormats = new Map<string, { count: number; codec: string; dims: string }>();
+  let chunkTotalSize = 0;
+
+  for (const item of chunk) {
+    const parts = item.streamInfo.split(' ');
+    const codec = parts[0] || 'unknown';
+    const dims = parts[1] || 'unknown';
+    const key = `${codec}-${dims}`;
+
+    if (item.isVideo) {
+      const existing = videoFormats.get(key) || { count: 0, codec, dims };
+      videoFormats.set(key, { ...existing, count: existing.count + 1 });
+    } else {
+      const existing = imageFormats.get(key) || { count: 0, codec, dims };
+      imageFormats.set(key, { ...existing, count: existing.count + 1 });
+    }
+    chunkTotalSize += parseFloat(item.fileSizeMB);
+  }
+
+  const formatParts: string[] = [];
+  if (imageFormats.size > 0) {
+    const summary = Array.from(imageFormats.values())
+      .map((i) => `${i.count} ${i.codec} image${i.count > 1 ? 's' : ''} at ${i.dims}`)
+      .join(', ');
+    formatParts.push(summary);
+  }
+  if (videoFormats.size > 0) {
+    const summary = Array.from(videoFormats.values())
+      .map((i) => `${i.count} ${i.codec} video${i.count > 1 ? 's' : ''} at ${i.dims}`)
+      .join(', ');
+    formatParts.push(summary);
+  }
+
+  const escapedSummary = escapeMarkdownV2(formatParts.join(', '));
+  const escapedSize = escapeMarkdownV2(chunkTotalSize.toFixed(1));
+  const sizeLabel = `\`${escapedSummary}, ${escapedSize}MB total\``;
+
+  if (isFirstChunk) {
+    const escapedTitle = escapeMarkdownV2(normalizeLineBreaks(title));
+    const escapedUrl = escapeMarkdownV2Url(url);
+    return `[${escapedTitle}](${escapedUrl})\n${sizeLabel}`;
+  }
+  return sizeLabel;
+}

--- a/src/utils/caption.ts
+++ b/src/utils/caption.ts
@@ -1,0 +1,114 @@
+import { escapeMarkdownV2, escapeMarkdownV2Url, normalizeLineBreaks } from './markdown.js';
+
+// Telegram media captions are capped at 1024 chars.
+const TELEGRAM_CAPTION_MAX = 1024;
+
+export interface CaptionMediaItem {
+  isVideo: boolean;
+  streamInfo: string;
+  fileSizeMB: string;
+}
+
+/**
+ * Truncates a raw (pre-escape) title so the final caption fits within
+ * Telegram's 1024-char cap. `suffixLength` is the already-known escaped
+ * tail length (link syntax + info/size block). A 2x factor conservatively
+ * accounts for MarkdownV2 escape expansion.
+ */
+function truncateTitleForCaption(title: string, suffixLength: number): string {
+  // The result is MarkdownV2 inline-link label text, which must be single-line:
+  // a literal newline inside [label](url) makes Telegram reject the caption (400).
+  const oneLine = title.replace(/\s*\n+\s*/g, ' ');
+  const budget = TELEGRAM_CAPTION_MAX - suffixLength - 1; // -1 for the ellipsis
+  if (budget <= 0) return '';
+  const maxRawTitle = Math.floor(budget / 2);
+  if (oneLine.length <= maxRawTitle) return oneLine;
+  // budget === 1 → maxRawTitle === 0: no room for even one title char.
+  if (maxRawTitle <= 0) return '';
+  // Slice by code point (not UTF-16 unit) so a multi-byte emoji at the cut
+  // boundary isn't split into a lone surrogate — Telegram rejects those (400).
+  // Each code point still contributes ≤ 2 escaped units, so the cap holds.
+  const truncated = Array.from(oneLine)
+    .slice(0, maxRawTitle - 1)
+    .join('');
+  return truncated.trimEnd() + '…';
+}
+
+export function buildSingleCaption(title: string, url: string, item: CaptionMediaItem): string {
+  const escapedUrl = escapeMarkdownV2Url(url);
+  const escapedInfo = escapeMarkdownV2(item.streamInfo);
+  const escapedSize = escapeMarkdownV2(item.fileSizeMB);
+  const infoBlock = `\`${escapedInfo}, ${escapedSize}MB\``;
+  // Fixed tail: `](url)\n\`info, sizeMB\``, plus the leading `[` of the link
+  const suffix = `](${escapedUrl})\n${infoBlock}`;
+  // If even a zero-length title plus the link would exceed the cap
+  // (pathologically long URL), drop the link entirely and emit info only.
+  if (suffix.length + 2 > TELEGRAM_CAPTION_MAX) return infoBlock;
+  const truncated = truncateTitleForCaption(normalizeLineBreaks(title), suffix.length + 1);
+  return `[${escapeMarkdownV2(truncated)}${suffix}`;
+}
+
+export function buildGroupCaption(
+  title: string,
+  url: string,
+  chunk: CaptionMediaItem[],
+  isFirstChunk: boolean,
+): string {
+  const imageFormats = new Map<string, { count: number; codec: string; dims: string | null }>();
+  const videoFormats = new Map<string, { count: number; codec: string; dims: string | null }>();
+  let chunkTotalSize = 0;
+
+  for (const item of chunk) {
+    const tokens = item.streamInfo.trim().split(/\s+/);
+    const codec = tokens[0] || 'unknown';
+    // Only accept WxH — otherwise the token is bitrate/sample-rate from an
+    // audio stream, not dimensions. Prevents "opus image at 128kbps" for audio.
+    const dims = tokens[1] && /^\d+x\d+$/.test(tokens[1]) ? tokens[1] : null;
+    const key = `${codec}-${dims ?? ''}`;
+
+    if (item.isVideo) {
+      const existing = videoFormats.get(key) || { count: 0, codec, dims };
+      videoFormats.set(key, { ...existing, count: existing.count + 1 });
+    } else {
+      const existing = imageFormats.get(key) || { count: 0, codec, dims };
+      imageFormats.set(key, { ...existing, count: existing.count + 1 });
+    }
+    chunkTotalSize += parseFloat(item.fileSizeMB) || 0;
+  }
+
+  const formatParts: string[] = [];
+  if (imageFormats.size > 0) {
+    const summary = Array.from(imageFormats.values())
+      .map((i) => {
+        const suffix = i.dims ? ` at ${i.dims}` : '';
+        return `${i.count} ${i.codec} image${i.count > 1 ? 's' : ''}${suffix}`;
+      })
+      .join(', ');
+    formatParts.push(summary);
+  }
+  if (videoFormats.size > 0) {
+    const summary = Array.from(videoFormats.values())
+      .map((i) => {
+        const suffix = i.dims ? ` at ${i.dims}` : '';
+        return `${i.count} ${i.codec} video${i.count > 1 ? 's' : ''}${suffix}`;
+      })
+      .join(', ');
+    formatParts.push(summary);
+  }
+
+  const escapedSize = escapeMarkdownV2(chunkTotalSize.toFixed(1));
+  const escapedSummary = escapeMarkdownV2(formatParts.join(', '));
+  const sizeLabel = escapedSummary
+    ? `\`${escapedSummary}, ${escapedSize}MB total\``
+    : `\`${escapedSize}MB total\``;
+
+  if (isFirstChunk) {
+    const escapedUrl = escapeMarkdownV2Url(url);
+    const suffix = `](${escapedUrl})\n${sizeLabel}`;
+    // Same pathological-URL guard as the single-media case
+    if (suffix.length + 2 > TELEGRAM_CAPTION_MAX) return sizeLabel;
+    const truncated = truncateTitleForCaption(normalizeLineBreaks(title), suffix.length + 1);
+    return `[${escapeMarkdownV2(truncated)}${suffix}`;
+  }
+  return sizeLabel;
+}

--- a/src/utils/chatAction.ts
+++ b/src/utils/chatAction.ts
@@ -1,6 +1,5 @@
 import { Context } from 'grammy';
 import { logger } from './logger.js';
-import { withRetry } from './retry.js';
 
 export type ChatAction =
   | 'typing'
@@ -11,8 +10,8 @@ export type ChatAction =
 
 /**
  * Manages Telegram chat action indicators (typing, uploading, etc.)
- * with automatic periodic refresh using setTimeout recursion to
- * prevent overlapping retry chains.
+ * with automatic periodic refresh. Uses best-effort sends for ticks
+ * since chat actions are cosmetic signals.
  */
 export class ChatActionManager {
   private timer: NodeJS.Timeout | null = null;
@@ -28,9 +27,9 @@ export class ChatActionManager {
     this.stop();
     this.stopped = false;
     try {
-      await this.sendAction(action);
+      await this.ctx.api.sendChatAction(this.chatId, action);
     } catch (error) {
-      logger.error('Failed to start chat action', { error });
+      logger.debug('Failed to start chat action', { error });
       return;
     }
     this.scheduleNext(action);
@@ -42,24 +41,14 @@ export class ChatActionManager {
       if (this.inFlight || this.stopped) return;
       this.inFlight = true;
       try {
-        await this.sendAction(action);
-      } catch (error) {
-        if (!(error instanceof Error) || !error.message?.includes('Network request')) {
-          logger.error('Failed to send chat action', { error });
-        }
+        await this.ctx.api.sendChatAction(this.chatId, action);
+      } catch {
+        // Best-effort cosmetic signal — failures are non-critical
       } finally {
         this.inFlight = false;
         if (!this.stopped) this.scheduleNext(action);
       }
     }, 1000);
-  }
-
-  private async sendAction(action: ChatAction): Promise<void> {
-    await withRetry(() => this.ctx.api.sendChatAction(this.chatId, action), {
-      maxAttempts: 5,
-      initialDelay: 500,
-      maxDelay: 3000,
-    });
   }
 
   stop(): void {

--- a/src/utils/chatAction.ts
+++ b/src/utils/chatAction.ts
@@ -1,0 +1,72 @@
+import { Context } from 'grammy';
+import { logger } from './logger.js';
+import { withRetry } from './retry.js';
+
+export type ChatAction =
+  | 'typing'
+  | 'upload_photo'
+  | 'upload_video'
+  | 'upload_voice'
+  | 'upload_document';
+
+/**
+ * Manages Telegram chat action indicators (typing, uploading, etc.)
+ * with automatic periodic refresh using setTimeout recursion to
+ * prevent overlapping retry chains.
+ */
+export class ChatActionManager {
+  private timer: NodeJS.Timeout | null = null;
+  private inFlight = false;
+  private stopped = false;
+
+  constructor(
+    private ctx: Context,
+    private chatId: number,
+  ) {}
+
+  async start(action: ChatAction): Promise<void> {
+    this.stop();
+    this.stopped = false;
+    try {
+      await this.sendAction(action);
+    } catch (error) {
+      logger.error('Failed to start chat action', { error });
+      return;
+    }
+    this.scheduleNext(action);
+  }
+
+  private scheduleNext(action: ChatAction): void {
+    if (this.stopped) return;
+    this.timer = setTimeout(async () => {
+      if (this.inFlight || this.stopped) return;
+      this.inFlight = true;
+      try {
+        await this.sendAction(action);
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message?.includes('Network request')) {
+          logger.error('Failed to send chat action', { error });
+        }
+      } finally {
+        this.inFlight = false;
+        if (!this.stopped) this.scheduleNext(action);
+      }
+    }, 1000);
+  }
+
+  private async sendAction(action: ChatAction): Promise<void> {
+    await withRetry(() => this.ctx.api.sendChatAction(this.chatId, action), {
+      maxAttempts: 5,
+      initialDelay: 500,
+      maxDelay: 3000,
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/utils/chatAction.ts
+++ b/src/utils/chatAction.ts
@@ -1,0 +1,65 @@
+import { Context } from 'grammy';
+import { logger } from './logger.js';
+
+export type ChatAction =
+  | 'typing'
+  | 'upload_photo'
+  | 'upload_video'
+  | 'upload_voice'
+  | 'upload_document';
+
+/**
+ * Manages Telegram chat action indicators (typing, uploading, etc.)
+ * with automatic periodic refresh. Uses best-effort sends for ticks
+ * since chat actions are cosmetic signals.
+ */
+export class ChatActionManager {
+  private timer: NodeJS.Timeout | null = null;
+  private stopped = false;
+  // Bumped on every start()/stop() so a tick scheduled by a previous run bails
+  // instead of orphaning a parallel timer chain when start() is called again.
+  private generation = 0;
+
+  constructor(
+    private ctx: Context,
+    private chatId: number,
+  ) {}
+
+  async start(action: ChatAction): Promise<void> {
+    this.stop();
+    this.stopped = false;
+    const gen = ++this.generation;
+    try {
+      await this.ctx.api.sendChatAction(this.chatId, action);
+    } catch (error) {
+      logger.debug('Failed to start chat action', { error });
+      return;
+    }
+    this.scheduleNext(action, gen);
+  }
+
+  private scheduleNext(action: ChatAction, gen: number): void {
+    if (this.stopped || gen !== this.generation) return;
+    this.timer = setTimeout(async () => {
+      if (this.stopped || gen !== this.generation) return;
+      try {
+        await this.ctx.api.sendChatAction(this.chatId, action);
+      } catch {
+        // Best-effort cosmetic signal — failures are non-critical
+      } finally {
+        if (!this.stopped && gen === this.generation) this.scheduleNext(action, gen);
+      }
+      // 4s — Telegram displays chat actions for ~5s, so this refreshes
+      // just before expiry while using 5x fewer API calls than 1s ticks
+    }, 4000);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.generation++;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -2,6 +2,7 @@ import { rm, readdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { logger } from './logger.js';
 import { env } from '../config/env.js';
+import { assertSafePath } from './pathSafety.js';
 
 export class Cleanup {
   private static readonly MAX_AGE = 24 * 60 * 60 * 1000;
@@ -11,7 +12,10 @@ export class Cleanup {
     try {
       const files = await readdir(env.TMP_DIR);
       await Promise.all(
-        files.map((file) => rm(join(env.TMP_DIR, file), { recursive: true, force: true })),
+        files.map((file) => {
+          const filePath = assertSafePath(join(env.TMP_DIR, file), env.TMP_DIR);
+          return rm(filePath, { recursive: true, force: true });
+        }),
       );
       logger.info(`Initialized temp directory: ${env.TMP_DIR}`);
     } catch (error) {
@@ -28,7 +32,7 @@ export class Cleanup {
 
       await Promise.all(
         files.map(async (file) => {
-          const filePath = join(env.TMP_DIR, file);
+          const filePath = assertSafePath(join(env.TMP_DIR, file), env.TMP_DIR);
           const stats = await stat(filePath);
           if (now - stats.mtimeMs > this.MAX_AGE) {
             await rm(filePath, { recursive: true, force: true });
@@ -44,6 +48,7 @@ export class Cleanup {
   }
 
   public static startPeriodicCleanup(interval = 60 * 60 * 1000): void {
+    if (this.cleanupTimer) return;
     this.cleanupTimer = setInterval(() => {
       void this.cleanOldFiles();
     }, interval);

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -4,59 +4,55 @@ import { logger } from './logger.js';
 import { env } from '../config/env.js';
 
 export class Cleanup {
-  private static readonly MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+  private static readonly MAX_AGE = 24 * 60 * 60 * 1000;
+  private static cleanupTimer: NodeJS.Timeout | null = null;
 
-  /**
-   * Ensures the tmp directory exists and is empty
-   */
   public static async init(): Promise<void> {
     try {
-      // Only remove contents of the directory, not the directory itself
       const files = await readdir(env.TMP_DIR);
       await Promise.all(
         files.map((file) => rm(join(env.TMP_DIR, file), { recursive: true, force: true })),
       );
       logger.info(`Initialized temp directory: ${env.TMP_DIR}`);
     } catch (error) {
-      // Ignore if directory is empty or doesn't exist
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.error('Error initializing temp directory', error);
+        logger.error('Error initializing temp directory', { error });
       }
     }
   }
 
-  /**
-   * Cleans up old files from the tmp directory
-   */
   public static async cleanOldFiles(): Promise<void> {
     try {
       const files = await readdir(env.TMP_DIR);
       const now = Date.now();
 
-      for (const file of files) {
-        const filePath = join(env.TMP_DIR, file);
-        const stats = await stat(filePath);
-
-        if (now - stats.mtimeMs > this.MAX_AGE) {
-          await rm(filePath, { recursive: true, force: true });
-          logger.info(`Removed old file: ${file}`);
-        }
-      }
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = join(env.TMP_DIR, file);
+          const stats = await stat(filePath);
+          if (now - stats.mtimeMs > this.MAX_AGE) {
+            await rm(filePath, { recursive: true, force: true });
+            logger.info(`Removed old file: ${file}`);
+          }
+        }),
+      );
     } catch (error) {
-      // Only log if it's not a "no such file or directory" error
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.error('Error cleaning up old files', error);
+        logger.error('Error cleaning up old files', { error });
       }
     }
   }
 
-  /**
-   * Starts periodic cleanup of old files
-   */
   public static startPeriodicCleanup(interval = 60 * 60 * 1000): void {
-    // Default: 1 hour
-    setInterval(() => {
+    this.cleanupTimer = setInterval(() => {
       void this.cleanOldFiles();
     }, interval);
+  }
+
+  public static stop(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
   }
 }

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -5,7 +5,7 @@ import { env } from '../config/env.js';
 import { assertSafePath } from './pathSafety.js';
 
 export class Cleanup {
-  private static readonly MAX_AGE = 24 * 60 * 60 * 1000;
+  private static readonly MAX_AGE = 7 * 24 * 60 * 60 * 1000; // Match download cache TTL
   private static cleanupTimer: NodeJS.Timeout | null = null;
 
   public static async init(): Promise<void> {

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -2,61 +2,78 @@ import { rm, readdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { logger } from './logger.js';
 import { env } from '../config/env.js';
+import { assertSafePath } from './pathSafety.js';
+import { getCachedFilePaths } from '../handlers/message.js';
 
 export class Cleanup {
-  private static readonly MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+  private static readonly MAX_AGE = 7 * 24 * 60 * 60 * 1000; // Match download cache TTL
+  private static cleanupTimer: NodeJS.Timeout | null = null;
 
-  /**
-   * Ensures the tmp directory exists and is empty
-   */
   public static async init(): Promise<void> {
     try {
-      // Only remove contents of the directory, not the directory itself
       const files = await readdir(env.TMP_DIR);
       await Promise.all(
-        files.map((file) => rm(join(env.TMP_DIR, file), { recursive: true, force: true })),
+        files.map((file) => {
+          const filePath = assertSafePath(join(env.TMP_DIR, file), env.TMP_DIR);
+          return rm(filePath, { recursive: true, force: true });
+        }),
       );
       logger.info(`Initialized temp directory: ${env.TMP_DIR}`);
     } catch (error) {
-      // Ignore if directory is empty or doesn't exist
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.error('Error initializing temp directory', error);
+        logger.error('Error initializing temp directory', { error });
       }
     }
   }
 
-  /**
-   * Cleans up old files from the tmp directory
-   */
   public static async cleanOldFiles(): Promise<void> {
     try {
       const files = await readdir(env.TMP_DIR);
       const now = Date.now();
+      // Files owned by a live cache entry are the cache's responsibility to evict;
+      // skip them so a stale download-tool mtime can't delete a file that's still
+      // cached (and possibly mid-send). The sweep then only reaps true orphans.
+      const live = getCachedFilePaths();
 
-      for (const file of files) {
-        const filePath = join(env.TMP_DIR, file);
-        const stats = await stat(filePath);
-
-        if (now - stats.mtimeMs > this.MAX_AGE) {
-          await rm(filePath, { recursive: true, force: true });
-          logger.info(`Removed old file: ${file}`);
-        }
-      }
+      await Promise.all(
+        files.map(async (file) => {
+          try {
+            const filePath = assertSafePath(join(env.TMP_DIR, file), env.TMP_DIR);
+            if (live.has(filePath)) return;
+            const stats = await stat(filePath);
+            if (now - stats.mtimeMs > this.MAX_AGE) {
+              await rm(filePath, { recursive: true, force: true });
+              logger.info(`Removed old file: ${file}`);
+            }
+          } catch (error) {
+            // A concurrent cleanup (cache-evict / per-request) may have removed
+            // the file between readdir and stat — ENOENT is expected; ignore it
+            // and never let one file abort the whole sweep.
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+              logger.warn('Failed to clean old file', { file, error });
+            }
+          }
+        }),
+      );
     } catch (error) {
-      // Only log if it's not a "no such file or directory" error
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        logger.error('Error cleaning up old files', error);
+        logger.error('Error cleaning up old files', { error });
       }
     }
   }
 
-  /**
-   * Starts periodic cleanup of old files
-   */
   public static startPeriodicCleanup(interval = 60 * 60 * 1000): void {
-    // Default: 1 hour
-    setInterval(() => {
+    if (this.cleanupTimer) return;
+    this.cleanupTimer = setInterval(() => {
       void this.cleanOldFiles();
     }, interval);
+    this.cleanupTimer.unref();
+  }
+
+  public static stop(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
   }
 }

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,37 @@
+/**
+ * Counting semaphore for limiting concurrent async operations.
+ */
+export class Semaphore {
+  private readonly queue: (() => void)[] = [];
+  private active = 0;
+
+  constructor(private readonly maxConcurrent: number) {}
+
+  private acquire(): Promise<void> {
+    if (this.active < this.maxConcurrent) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      this.active++;
+      next();
+    }
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -5,7 +5,11 @@ export class Semaphore {
   private readonly queue: (() => void)[] = [];
   private active = 0;
 
-  constructor(private readonly maxConcurrent: number) {}
+  constructor(private readonly maxConcurrent: number) {
+    if (!Number.isFinite(maxConcurrent) || maxConcurrent <= 0) {
+      throw new RangeError(`maxConcurrent must be a positive integer, got: ${maxConcurrent}`);
+    }
+  }
 
   private acquire(): Promise<void> {
     if (this.active < this.maxConcurrent) {

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,42 @@
+/**
+ * Counting semaphore for limiting concurrent async operations.
+ */
+export class Semaphore {
+  private readonly queue: (() => void)[] = [];
+  private active = 0;
+
+  constructor(private readonly maxConcurrent: number) {
+    if (!Number.isInteger(maxConcurrent) || maxConcurrent <= 0) {
+      throw new RangeError(`maxConcurrent must be a positive integer, got: ${maxConcurrent}`);
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.maxConcurrent) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    if (this.active <= 0) throw new Error('Semaphore invariant violated: release without acquire');
+    this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      this.active++;
+      next();
+    }
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,26 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface SafeExecOptions {
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024; // 50MB
+
+/**
+ * Execute a command safely using execFile (no shell interpolation).
+ * Prevents command injection by passing arguments as an array.
+ */
+export async function safeExec(
+  command: string,
+  args: string[],
+  options?: SafeExecOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync(command, args, {
+    timeout: options?.timeout ? options.timeout * 1000 : undefined,
+    maxBuffer: options?.maxBuffer ?? DEFAULT_MAX_BUFFER,
+  });
+}

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,44 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface SafeExecOptions {
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024; // 50MB
+// Backstop so stalled subprocesses don't pin a semaphore slot indefinitely.
+// Callers with known-longer workloads (downloads) pass a larger explicit timeout.
+const DEFAULT_TIMEOUT_SEC = 30;
+
+/**
+ * Execute a command safely using execFile (no shell interpolation).
+ * Prevents command injection by passing arguments as an array.
+ */
+export async function safeExec(
+  command: string,
+  args: string[],
+  options?: SafeExecOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  const timeoutSec = options?.timeout ?? DEFAULT_TIMEOUT_SEC;
+  const maxBuffer = options?.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  // Validate the resource backstops: Node treats timeout 0 as "no timeout",
+  // silently disabling the stalled-subprocess kill; a non-positive maxBuffer
+  // would reject all output. Fail fast instead of degrading quietly.
+  if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) {
+    throw new RangeError(
+      `safeExec timeout must be a positive number of seconds, got: ${timeoutSec}`,
+    );
+  }
+  if (!Number.isFinite(maxBuffer) || maxBuffer <= 0) {
+    throw new RangeError(
+      `safeExec maxBuffer must be a positive number of bytes, got: ${maxBuffer}`,
+    );
+  }
+  return execFileAsync(command, args, {
+    timeout: timeoutSec * 1000,
+    maxBuffer,
+  });
+}

--- a/src/utils/hostCooldown.ts
+++ b/src/utils/hostCooldown.ts
@@ -1,0 +1,76 @@
+import { logger } from './logger.js';
+
+// Default backoff when we see a 429 but can't parse a specific wait target.
+// 90s is empirically what Instagram's first 429 asks for; longer values risk
+// alienating users, shorter values risk extending the punitive window.
+const DEFAULT_COOLDOWN_MS = 90 * 1000;
+// Hard cap so a malformed parse can't lock a host out for hours.
+const MAX_COOLDOWN_MS = 30 * 60 * 1000;
+// Small buffer past the suggested time — just enough to clear the window.
+const POST_TARGET_BUFFER_MS = 5_000;
+
+const cooldowns = new Map<string, number>(); // host → epoch ms when allowed
+
+const RATE_LIMIT_PATTERNS: RegExp[] = [
+  /\b429\b/,
+  /Too Many Requests/i,
+  /HTTP Error 429/i,
+  /Waiting until \d{2}:\d{2}:\d{2}/i,
+];
+
+/**
+ * Returns ms remaining on a host's cooldown, or 0 if free.
+ * Self-prunes the entry once expired so the map doesn't accumulate stale keys.
+ */
+export function getCooldownRemainingMs(host: string): number {
+  const until = cooldowns.get(host);
+  if (until === undefined) return 0;
+  const remaining = until - Date.now();
+  if (remaining <= 0) {
+    cooldowns.delete(host);
+    return 0;
+  }
+  return remaining;
+}
+
+/**
+ * True if any of the known 429 patterns appear in the error message.
+ * Used by callers to decide whether to call applyRateLimitFromError.
+ */
+export function isRateLimitError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return RATE_LIMIT_PATTERNS.some((p) => p.test(msg));
+}
+
+/**
+ * Parse gallery-dl's "Waiting until HH:MM:SS" hint to an absolute epoch ms.
+ * Falls back to DEFAULT_COOLDOWN_MS from now if no timestamp is present.
+ * Capped at MAX_COOLDOWN_MS to bound damage from a misread or stale clock.
+ */
+export function computeCooldownTarget(errorMessage: string, now: number = Date.now()): number {
+  const match = errorMessage.match(/Waiting until (\d{2}):(\d{2}):(\d{2})/i);
+  if (!match) return now + DEFAULT_COOLDOWN_MS;
+
+  const [, hh, mm, ss] = match;
+  const today = new Date(now);
+  today.setUTCHours(Number(hh), Number(mm), Number(ss), 0);
+  let target = today.getTime() + POST_TARGET_BUFFER_MS;
+
+  // Roll forward if HH:MM:SS already passed today (gallery-dl logs UTC).
+  if (target <= now) target += 24 * 60 * 60 * 1000;
+
+  const cappedDelta = Math.min(target - now, MAX_COOLDOWN_MS);
+  return now + cappedDelta;
+}
+
+/**
+ * Records a cooldown for a host based on a rate-limit error message.
+ * Returns the wait remaining in seconds (rounded up) so callers can echo it.
+ */
+export function applyRateLimitFromError(host: string, errorMessage: string): number {
+  const target = computeCooldownTarget(errorMessage);
+  cooldowns.set(host, target);
+  const seconds = Math.ceil((target - Date.now()) / 1000);
+  logger.warn(`Host ${host} entered cooldown for ${seconds}s after rate-limit signal`);
+  return seconds;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,13 +1,19 @@
 class Logger {
   private static instance: Logger;
+  private static readonly LEVEL_RANK = new Map([
+    ['debug', 0],
+    ['info', 1],
+    ['warn', 2],
+    ['error', 3],
+  ]);
   private appName = 'tgmr';
-  private logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info';
+  private minRank: number;
+  private logLevel: string;
 
   private constructor() {
     const envLogLevel = process.env.LOG_LEVEL?.toLowerCase();
-    if (envLogLevel && ['debug', 'info', 'warn', 'error'].includes(envLogLevel)) {
-      this.logLevel = envLogLevel as 'debug' | 'info' | 'warn' | 'error';
-    }
+    this.logLevel = envLogLevel && Logger.LEVEL_RANK.has(envLogLevel) ? envLogLevel : 'info';
+    this.minRank = Logger.LEVEL_RANK.get(this.logLevel) ?? 1;
   }
 
   public static getInstance(): Logger {
@@ -18,13 +24,11 @@ class Logger {
   }
 
   private shouldLog(level: string): boolean {
-    const levels = ['debug', 'info', 'warn', 'error'];
-    return levels.indexOf(level.toLowerCase()) >= levels.indexOf(this.logLevel);
+    return (Logger.LEVEL_RANK.get(level.toLowerCase()) ?? 0) >= this.minRank;
   }
 
   private formatMessage(level: string, message: string, context?: Record<string, unknown>): string {
-    let formattedMessage = `${this.appName} | ${level}:`;
-
+    let formatted = `${this.appName} | ${level}:`;
     if (context) {
       const essentialKeys = ['type', 'chat', 'from', 'msgId', 'requestId'];
       const essentialContext = Object.entries(context)
@@ -32,30 +36,28 @@ class Logger {
         .map(([key, value]) => `${key}=${value}`)
         .join(' ');
       if (essentialContext) {
-        formattedMessage += ` [${essentialContext}]`;
+        formatted += ` [${essentialContext}]`;
       }
     }
-
-    formattedMessage += ` ${message}`;
-    return formattedMessage;
+    formatted += ` ${message}`;
+    return formatted;
   }
 
   private colorize(level: string, message: string): string {
-    const colors = {
-      RESET: '\x1b[0m',
+    const colors: Record<string, string> = {
       ERROR: '\x1b[31m',
       WARN: '\x1b[33m',
       INFO: '\x1b[36m',
       DEBUG: '\x1b[90m',
-    } as const;
-    const color = colors[level as keyof typeof colors] || colors.INFO;
-    return `${color}${message}${colors.RESET}`;
+    };
+    const color = colors[level] || colors.INFO;
+    return `${color}${message}\x1b[0m`;
   }
 
   public info(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('info')) return;
-    const formattedMessage = this.formatMessage('INFO', message, context);
-    process.stdout.write(this.colorize('INFO', formattedMessage) + '\n');
+    const formatted = this.formatMessage('INFO', message, context);
+    process.stdout.write(this.colorize('INFO', formatted) + '\n');
   }
 
   public error(message: string, context?: Record<string, unknown>): void {
@@ -67,20 +69,20 @@ class Logger {
     } else if (error) {
       errorDetails = `: ${String(error)}`;
     }
-    const formattedMessage = this.formatMessage('ERROR', `${message}${errorDetails}`, context);
-    console.error(this.colorize('ERROR', formattedMessage));
+    const formatted = this.formatMessage('ERROR', `${message}${errorDetails}`, context);
+    process.stderr.write(this.colorize('ERROR', formatted) + '\n');
   }
 
   public warn(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('warn')) return;
-    const formattedMessage = this.formatMessage('WARN', message, context);
-    console.warn(this.colorize('WARN', formattedMessage));
+    const formatted = this.formatMessage('WARN', message, context);
+    process.stderr.write(this.colorize('WARN', formatted) + '\n');
   }
 
   public debug(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('debug')) return;
-    const formattedMessage = this.formatMessage('DEBUG', message, context);
-    process.stdout.write(this.colorize('DEBUG', formattedMessage) + '\n');
+    const formatted = this.formatMessage('DEBUG', message, context);
+    process.stdout.write(this.colorize('DEBUG', formatted) + '\n');
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,11 +5,24 @@ const LEVEL_RANK = new Map([
   ['error', 3],
 ]);
 
-const ESSENTIAL_KEYS = new Set(['type', 'chat', 'from', 'msgId', 'requestId']);
+const LEVEL_PAD: Record<string, string> = {
+  DEBUG: 'DEBUG',
+  INFO: 'INFO ',
+  WARN: 'WARN ',
+  ERROR: 'ERROR',
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+  ERROR: '\x1b[31m',
+  WARN: '\x1b[33m',
+  INFO: '\x1b[36m',
+  DEBUG: '\x1b[90m',
+};
+
+const RESET = '\x1b[0m';
 
 class Logger {
   private static instance: Logger;
-  private appName = 'tgmr';
   private minRank: number;
 
   private constructor() {
@@ -29,37 +42,27 @@ class Logger {
     return (LEVEL_RANK.get(level) ?? 0) >= this.minRank;
   }
 
-  private formatMessage(level: string, message: string, context?: Record<string, unknown>): string {
-    let formatted = `${this.appName} | ${level}:`;
-    if (context) {
-      const essentialContext = Object.entries(context)
-        .filter(([key]) => ESSENTIAL_KEYS.has(key))
-        .map(([key, value]) => `${key}=${value}`)
-        .join(' ');
-      if (essentialContext) {
-        formatted += ` [${essentialContext}]`;
-      }
+  private formatContext(context?: Record<string, unknown>): string {
+    if (!context) return '';
+    const parts: string[] = [];
+    if (context.chat) {
+      const type = context.type === 'private' ? 'pm' : context.type === 'supergroup' ? 'sg' : 'grp';
+      parts.push(`${type}:${context.chat}`);
     }
-    formatted += ` ${message}`;
-    return formatted;
+    if (context.msgId) parts.push(String(context.msgId));
+    return parts.length > 0 ? ` [${parts.join(':')}]` : '';
   }
 
-  private colorize(level: string, message: string): string {
-    const colors: Record<string, string> = {
-      ERROR: '\x1b[31m',
-      WARN: '\x1b[33m',
-      INFO: '\x1b[36m',
-      DEBUG: '\x1b[90m',
-    };
-    const color = colors[level] || colors.INFO;
-    return `${color}${message}\x1b[0m`;
+  private format(level: string, message: string, context?: Record<string, unknown>): string {
+    const ts = new Date().toISOString();
+    const ctx = this.formatContext(context);
+    return `${ts} ${LEVEL_PAD[level] || level}${ctx} ${message}`;
   }
 
   public info(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('info')) return;
-    process.stdout.write(
-      this.colorize('INFO', this.formatMessage('INFO', message, context)) + '\n',
-    );
+    const line = this.format('INFO', message, context);
+    process.stdout.write(`${LEVEL_COLORS.INFO}${line}${RESET}\n`);
   }
 
   public error(message: string, context?: Record<string, unknown>): void {
@@ -71,24 +74,20 @@ class Logger {
     } else if (error) {
       errorDetails = `: ${String(error)}`;
     }
-    process.stderr.write(
-      this.colorize('ERROR', this.formatMessage('ERROR', `${message}${errorDetails}`, context)) +
-        '\n',
-    );
+    const line = this.format('ERROR', `${message}${errorDetails}`, context);
+    process.stderr.write(`${LEVEL_COLORS.ERROR}${line}${RESET}\n`);
   }
 
   public warn(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('warn')) return;
-    process.stderr.write(
-      this.colorize('WARN', this.formatMessage('WARN', message, context)) + '\n',
-    );
+    const line = this.format('WARN', message, context);
+    process.stderr.write(`${LEVEL_COLORS.WARN}${line}${RESET}\n`);
   }
 
   public debug(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('debug')) return;
-    process.stdout.write(
-      this.colorize('DEBUG', this.formatMessage('DEBUG', message, context)) + '\n',
-    );
+    const line = this.format('DEBUG', message, context);
+    process.stdout.write(`${LEVEL_COLORS.DEBUG}${line}${RESET}\n`);
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,19 +1,21 @@
+const LEVEL_RANK = new Map([
+  ['debug', 0],
+  ['info', 1],
+  ['warn', 2],
+  ['error', 3],
+]);
+
+const ESSENTIAL_KEYS = new Set(['type', 'chat', 'from', 'msgId', 'requestId']);
+
 class Logger {
   private static instance: Logger;
-  private static readonly LEVEL_RANK = new Map([
-    ['debug', 0],
-    ['info', 1],
-    ['warn', 2],
-    ['error', 3],
-  ]);
   private appName = 'tgmr';
   private minRank: number;
-  private logLevel: string;
 
   private constructor() {
     const envLogLevel = process.env.LOG_LEVEL?.toLowerCase();
-    this.logLevel = envLogLevel && Logger.LEVEL_RANK.has(envLogLevel) ? envLogLevel : 'info';
-    this.minRank = Logger.LEVEL_RANK.get(this.logLevel) ?? 1;
+    const validLevel = envLogLevel && LEVEL_RANK.has(envLogLevel) ? envLogLevel : 'info';
+    this.minRank = LEVEL_RANK.get(validLevel) ?? 1;
   }
 
   public static getInstance(): Logger {
@@ -24,15 +26,14 @@ class Logger {
   }
 
   private shouldLog(level: string): boolean {
-    return (Logger.LEVEL_RANK.get(level.toLowerCase()) ?? 0) >= this.minRank;
+    return (LEVEL_RANK.get(level) ?? 0) >= this.minRank;
   }
 
   private formatMessage(level: string, message: string, context?: Record<string, unknown>): string {
     let formatted = `${this.appName} | ${level}:`;
     if (context) {
-      const essentialKeys = ['type', 'chat', 'from', 'msgId', 'requestId'];
       const essentialContext = Object.entries(context)
-        .filter(([key]) => essentialKeys.includes(key))
+        .filter(([key]) => ESSENTIAL_KEYS.has(key))
         .map(([key, value]) => `${key}=${value}`)
         .join(' ');
       if (essentialContext) {
@@ -56,8 +57,9 @@ class Logger {
 
   public info(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('info')) return;
-    const formatted = this.formatMessage('INFO', message, context);
-    process.stdout.write(this.colorize('INFO', formatted) + '\n');
+    process.stdout.write(
+      this.colorize('INFO', this.formatMessage('INFO', message, context)) + '\n',
+    );
   }
 
   public error(message: string, context?: Record<string, unknown>): void {
@@ -69,20 +71,24 @@ class Logger {
     } else if (error) {
       errorDetails = `: ${String(error)}`;
     }
-    const formatted = this.formatMessage('ERROR', `${message}${errorDetails}`, context);
-    process.stderr.write(this.colorize('ERROR', formatted) + '\n');
+    process.stderr.write(
+      this.colorize('ERROR', this.formatMessage('ERROR', `${message}${errorDetails}`, context)) +
+        '\n',
+    );
   }
 
   public warn(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('warn')) return;
-    const formatted = this.formatMessage('WARN', message, context);
-    process.stderr.write(this.colorize('WARN', formatted) + '\n');
+    process.stderr.write(
+      this.colorize('WARN', this.formatMessage('WARN', message, context)) + '\n',
+    );
   }
 
   public debug(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('debug')) return;
-    const formatted = this.formatMessage('DEBUG', message, context);
-    process.stdout.write(this.colorize('DEBUG', formatted) + '\n');
+    process.stdout.write(
+      this.colorize('DEBUG', this.formatMessage('DEBUG', message, context)) + '\n',
+    );
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,10 +1,9 @@
 class Logger {
   private static instance: Logger;
   private appName = 'tgmr';
-  private logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info'; // Default to info level
+  private logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info';
 
   private constructor() {
-    // Set log level from environment variable if present
     const envLogLevel = process.env.LOG_LEVEL?.toLowerCase();
     if (envLogLevel && ['debug', 'info', 'warn', 'error'].includes(envLogLevel)) {
       this.logLevel = envLogLevel as 'debug' | 'info' | 'warn' | 'error';
@@ -20,15 +19,12 @@ class Logger {
 
   private shouldLog(level: string): boolean {
     const levels = ['debug', 'info', 'warn', 'error'];
-    const currentLevel = levels.indexOf(this.logLevel);
-    const messageLevel = levels.indexOf(level.toLowerCase());
-    return messageLevel >= currentLevel;
+    return levels.indexOf(level.toLowerCase()) >= levels.indexOf(this.logLevel);
   }
 
   private formatMessage(level: string, message: string, context?: Record<string, unknown>): string {
     let formattedMessage = `${this.appName} | ${level}:`;
 
-    // Only add essential context
     if (context) {
       const essentialKeys = ['type', 'chat', 'from', 'msgId', 'requestId'];
       const essentialContext = Object.entries(context)
@@ -47,12 +43,11 @@ class Logger {
   private colorize(level: string, message: string): string {
     const colors = {
       RESET: '\x1b[0m',
-      ERROR: '\x1b[31m', // Red
-      WARN: '\x1b[33m', // Yellow
-      INFO: '\x1b[36m', // Cyan
-      DEBUG: '\x1b[90m', // Gray
+      ERROR: '\x1b[31m',
+      WARN: '\x1b[33m',
+      INFO: '\x1b[36m',
+      DEBUG: '\x1b[90m',
     } as const;
-
     const color = colors[level as keyof typeof colors] || colors.INFO;
     return `${color}${message}${colors.RESET}`;
   }
@@ -63,15 +58,15 @@ class Logger {
     process.stdout.write(this.colorize('INFO', formattedMessage) + '\n');
   }
 
-  public error(message: string, error?: unknown, context?: Record<string, unknown>): void {
+  public error(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('error')) return;
     let errorDetails = '';
+    const error = context?.error;
     if (error instanceof Error) {
       errorDetails = `: ${error.message}`;
     } else if (error) {
       errorDetails = `: ${String(error)}`;
     }
-
     const formattedMessage = this.formatMessage('ERROR', `${message}${errorDetails}`, context);
     console.error(this.colorize('ERROR', formattedMessage));
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,14 +1,34 @@
+const LEVEL_RANK = new Map([
+  ['debug', 0],
+  ['info', 1],
+  ['warn', 2],
+  ['error', 3],
+]);
+
+const LEVEL_PAD: Record<string, string> = {
+  DEBUG: 'DEBUG',
+  INFO: 'INFO ',
+  WARN: 'WARN ',
+  ERROR: 'ERROR',
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+  ERROR: '\x1b[31m',
+  WARN: '\x1b[33m',
+  INFO: '\x1b[36m',
+  DEBUG: '\x1b[90m',
+};
+
+const RESET = '\x1b[0m';
+
 class Logger {
   private static instance: Logger;
-  private appName = 'tgmr';
-  private logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info'; // Default to info level
+  private minRank: number;
 
   private constructor() {
-    // Set log level from environment variable if present
     const envLogLevel = process.env.LOG_LEVEL?.toLowerCase();
-    if (envLogLevel && ['debug', 'info', 'warn', 'error'].includes(envLogLevel)) {
-      this.logLevel = envLogLevel as 'debug' | 'info' | 'warn' | 'error';
-    }
+    const validLevel = envLogLevel && LEVEL_RANK.has(envLogLevel) ? envLogLevel : 'info';
+    this.minRank = LEVEL_RANK.get(validLevel) ?? 1;
   }
 
   public static getInstance(): Logger {
@@ -19,73 +39,75 @@ class Logger {
   }
 
   private shouldLog(level: string): boolean {
-    const levels = ['debug', 'info', 'warn', 'error'];
-    const currentLevel = levels.indexOf(this.logLevel);
-    const messageLevel = levels.indexOf(level.toLowerCase());
-    return messageLevel >= currentLevel;
+    return (LEVEL_RANK.get(level) ?? 0) >= this.minRank;
   }
 
-  private formatMessage(level: string, message: string, context?: Record<string, unknown>): string {
-    let formattedMessage = `${this.appName} | ${level}:`;
-
-    // Only add essential context
-    if (context) {
-      const essentialKeys = ['type', 'chat', 'from', 'msgId', 'requestId'];
-      const essentialContext = Object.entries(context)
-        .filter(([key]) => essentialKeys.includes(key))
-        .map(([key, value]) => `${key}=${value}`)
-        .join(' ');
-      if (essentialContext) {
-        formattedMessage += ` [${essentialContext}]`;
+  private formatContext(context?: Record<string, unknown>): string {
+    if (!context) return '';
+    const parts: string[] = [];
+    if (context.chat != null) {
+      const chatType = typeof context.type === 'string' ? context.type : undefined;
+      const tag =
+        chatType === 'private'
+          ? 'pm'
+          : chatType === 'supergroup'
+            ? 'sg'
+            : chatType === 'group'
+              ? 'grp'
+              : chatType === 'channel'
+                ? 'chn'
+                : 'chat';
+      parts.push(`${tag}:${context.chat}`);
+    }
+    if (context.msgId != null) parts.push(String(context.msgId));
+    // Include any extra scalar fields beyond the standard ones
+    for (const [key, value] of Object.entries(context)) {
+      if (key === 'chat' || key === 'type' || key === 'msgId' || key === 'error') continue;
+      if (value == null) continue;
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        parts.push(`${key}=${value}`);
       }
     }
-
-    formattedMessage += ` ${message}`;
-    return formattedMessage;
+    return parts.length > 0 ? ` [${parts.join(' ')}]` : '';
   }
 
-  private colorize(level: string, message: string): string {
-    const colors = {
-      RESET: '\x1b[0m',
-      ERROR: '\x1b[31m', // Red
-      WARN: '\x1b[33m', // Yellow
-      INFO: '\x1b[36m', // Cyan
-      DEBUG: '\x1b[90m', // Gray
-    } as const;
+  private format(level: string, message: string, context?: Record<string, unknown>): string {
+    const ts = new Date().toISOString();
+    const ctx = this.formatContext(context);
+    return `${ts} ${LEVEL_PAD[level] || level}${ctx} ${message}`;
+  }
 
-    const color = colors[level as keyof typeof colors] || colors.INFO;
-    return `${color}${message}${colors.RESET}`;
+  private write(stream: NodeJS.WriteStream, level: string, line: string): void {
+    const useColor = stream.isTTY && !process.env.NO_COLOR;
+    const color = LEVEL_COLORS[level] || '';
+    stream.write(useColor ? `${color}${line}${RESET}\n` : `${line}\n`);
   }
 
   public info(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('info')) return;
-    const formattedMessage = this.formatMessage('INFO', message, context);
-    process.stdout.write(this.colorize('INFO', formattedMessage) + '\n');
+    this.write(process.stdout, 'INFO', this.format('INFO', message, context));
   }
 
-  public error(message: string, error?: unknown, context?: Record<string, unknown>): void {
+  public error(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('error')) return;
     let errorDetails = '';
+    const error = context?.error;
     if (error instanceof Error) {
       errorDetails = `: ${error.message}`;
     } else if (error) {
       errorDetails = `: ${String(error)}`;
     }
-
-    const formattedMessage = this.formatMessage('ERROR', `${message}${errorDetails}`, context);
-    console.error(this.colorize('ERROR', formattedMessage));
+    this.write(process.stderr, 'ERROR', this.format('ERROR', `${message}${errorDetails}`, context));
   }
 
   public warn(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('warn')) return;
-    const formattedMessage = this.formatMessage('WARN', message, context);
-    console.warn(this.colorize('WARN', formattedMessage));
+    this.write(process.stderr, 'WARN', this.format('WARN', message, context));
   }
 
   public debug(message: string, context?: Record<string, unknown>): void {
     if (!this.shouldLog('debug')) return;
-    const formattedMessage = this.formatMessage('DEBUG', message, context);
-    process.stdout.write(this.colorize('DEBUG', formattedMessage) + '\n');
+    this.write(process.stdout, 'DEBUG', this.format('DEBUG', message, context));
   }
 }
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,32 @@
+const MARKDOWNV2_SPECIAL_CHARS = /[_*[\]()~`>#+\-=|{}.!\\]/g;
+const MARKDOWNV2_URL_CHARS = /[)\\]/g;
+
+/**
+ * Escapes special characters for Telegram's MarkdownV2 format.
+ * Use for text content (titles, descriptions, stream info).
+ */
+export function escapeMarkdownV2(text: string): string {
+  return text.replace(MARKDOWNV2_SPECIAL_CHARS, '\\$&');
+}
+
+/**
+ * Escapes only the characters that need escaping inside the URL part
+ * of a MarkdownV2 inline link [text](url). Per Telegram's spec, only
+ * ')' and '\' need escaping inside the URL parentheses.
+ */
+export function escapeMarkdownV2Url(url: string): string {
+  return url.replace(MARKDOWNV2_URL_CHARS, '\\$&');
+}
+
+/**
+ * Normalizes line breaks: CRLF to LF, strips whitespace-only lines,
+ * collapses 3+ consecutive newlines to double newline (paragraph break).
+ * Preserves single-character lines and legitimate paragraph separation.
+ */
+export function normalizeLineBreaks(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/^\s+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,22 +1,32 @@
 const MARKDOWNV2_SPECIAL_CHARS = /[_*[\]()~`>#+\-=|{}.!\\]/g;
+const MARKDOWNV2_URL_CHARS = /[)\\]/g;
 
 /**
  * Escapes special characters for Telegram's MarkdownV2 format.
+ * Use for text content (titles, descriptions, stream info).
  */
 export function escapeMarkdownV2(text: string): string {
   return text.replace(MARKDOWNV2_SPECIAL_CHARS, '\\$&');
 }
 
 /**
- * Normalizes line breaks in text to have at most one empty line between content.
+ * Escapes only the characters that need escaping inside the URL part
+ * of a MarkdownV2 inline link [text](url). Per Telegram's spec, only
+ * ')' and '\' need escaping inside the URL parentheses.
+ */
+export function escapeMarkdownV2Url(url: string): string {
+  return url.replace(MARKDOWNV2_URL_CHARS, '\\$&');
+}
+
+/**
+ * Normalizes line breaks: CRLF to LF, strips whitespace-only lines,
+ * collapses 3+ consecutive newlines to double newline (paragraph break).
+ * Preserves single-character lines and legitimate paragraph separation.
  */
 export function normalizeLineBreaks(text: string): string {
   return text
     .replace(/\r\n/g, '\n')
-    .replace(/^\s*(.)\s*$/gm, (match) => {
-      return match.trim().length > 1 ? match : '';
-    })
-    .replace(/(\n\s*(.)\s*\n\s*\2\s*\n\s*)+/g, '\n')
-    .replace(/\n\s*\n+/g, '\n')
+    .replace(/^\s+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,22 @@
+const MARKDOWNV2_SPECIAL_CHARS = /[_*[\]()~`>#+\-=|{}.!\\]/g;
+
+/**
+ * Escapes special characters for Telegram's MarkdownV2 format.
+ */
+export function escapeMarkdownV2(text: string): string {
+  return text.replace(MARKDOWNV2_SPECIAL_CHARS, '\\$&');
+}
+
+/**
+ * Normalizes line breaks in text to have at most one empty line between content.
+ */
+export function normalizeLineBreaks(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/^\s*(.)\s*$/gm, (match) => {
+      return match.trim().length > 1 ? match : '';
+    })
+    .replace(/(\n\s*(.)\s*\n\s*\2\s*\n\s*)+/g, '\n')
+    .replace(/\n\s*\n+/g, '\n')
+    .trim();
+}

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,15 +1,15 @@
 import { isAbsolute, relative, resolve } from 'path';
 
 /**
- * Validates that a file path resolves to a location within the allowed base directory.
- * Uses path.relative for cross-platform safety (works on both POSIX and Windows).
- * Returns the resolved absolute path if safe, throws otherwise.
+ * Validates that a file path resolves to a location strictly inside the base directory.
+ * Rejects paths equal to baseDir itself (only files within it are allowed).
+ * Uses path.relative for cross-platform safety.
  */
 export function assertSafePath(filePath: string, baseDir: string): string {
   const resolved = resolve(filePath);
   const base = resolve(baseDir);
   const rel = relative(base, resolved);
-  if (rel !== '' && (rel.startsWith('..') || isAbsolute(rel))) {
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(`Path traversal detected: ${filePath} is outside ${baseDir}`);
   }
   return resolved;

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,0 +1,16 @@
+import { isAbsolute, relative, resolve } from 'path';
+
+/**
+ * Validates that a file path resolves to a location strictly inside the base directory.
+ * Rejects paths equal to baseDir itself (only files within it are allowed).
+ * Uses path.relative for cross-platform safety.
+ */
+export function assertSafePath(filePath: string, baseDir: string): string {
+  const resolved = resolve(filePath);
+  const base = resolve(baseDir);
+  const rel = relative(base, resolved);
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`Path traversal detected: ${filePath} is outside ${baseDir}`);
+  }
+  return resolved;
+}

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,14 +1,15 @@
-import { resolve } from 'path';
+import { isAbsolute, relative, resolve } from 'path';
 
 /**
  * Validates that a file path resolves to a location within the allowed base directory.
- * Prevents path traversal attacks from external tool output.
+ * Uses path.relative for cross-platform safety (works on both POSIX and Windows).
  * Returns the resolved absolute path if safe, throws otherwise.
  */
 export function assertSafePath(filePath: string, baseDir: string): string {
   const resolved = resolve(filePath);
   const base = resolve(baseDir);
-  if (resolved !== base && !resolved.startsWith(base + '/')) {
+  const rel = relative(base, resolved);
+  if (rel !== '' && (rel.startsWith('..') || isAbsolute(rel))) {
     throw new Error(`Path traversal detected: ${filePath} is outside ${baseDir}`);
   }
   return resolved;

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'path';
+
+/**
+ * Validates that a file path resolves to a location within the allowed base directory.
+ * Prevents path traversal attacks from external tool output.
+ * Returns the resolved absolute path if safe, throws otherwise.
+ */
+export function assertSafePath(filePath: string, baseDir: string): string {
+  const resolved = resolve(filePath);
+  const base = resolve(baseDir);
+  if (resolved !== base && !resolved.startsWith(base + '/')) {
+    throw new Error(`Path traversal detected: ${filePath} is outside ${baseDir}`);
+  }
+  return resolved;
+}

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -2,87 +2,77 @@ import { env } from '../config/env.js';
 import { logger } from './logger.js';
 
 interface RateLimitEntry {
-  count: number;
-  lastReset: number;
-  cooldownUntil: number;
+  readonly count: number;
+  readonly lastReset: number;
+  readonly cooldownUntil: number;
 }
 
 export class RateLimiter {
-  private limits: Map<number, RateLimitEntry> = new Map();
-  private readonly resetInterval = 60 * 1000; // 1 minute in milliseconds
-
-  /**
-   * Checks if a user can make a request
-   * @param userId The user ID to check
-   * @returns Whether the user is allowed to make a request
-   */
-  public canMakeRequest(userId: number): boolean {
-    const now = Date.now();
-    const entry = this.getOrCreateEntry(userId, now);
-
-    // Check if user is in cooldown
-    if (entry.cooldownUntil > now) {
-      const secondsLeft = Math.ceil((entry.cooldownUntil - now) / 1000);
-      logger.info(`User ${userId} is in cooldown for ${secondsLeft} more seconds`);
-      return false;
-    }
-
-    // Check if rate limit exceeded
-    if (entry.count >= env.RATE_LIMIT) {
-      // Set cooldown period
-      entry.cooldownUntil = now + env.COOLDOWN * 1000;
-      logger.info(`User ${userId} has exceeded rate limit, cooldown for ${env.COOLDOWN}s`);
-      return false;
-    }
-
-    // User can make request
-    return true;
-  }
-
-  /**
-   * Records a request for a user
-   * @param userId The user ID making the request
-   */
-  public recordRequest(userId: number): void {
-    const now = Date.now();
-    const entry = this.getOrCreateEntry(userId, now);
-    entry.count++;
-    logger.debug(`User ${userId} has made ${entry.count}/${env.RATE_LIMIT} requests`);
-  }
-
-  /**
-   * Gets or creates a rate limit entry for a user
-   */
-  private getOrCreateEntry(userId: number, now: number): RateLimitEntry {
-    let entry = this.limits.get(userId);
-
-    // Create new entry if none exists
-    if (!entry) {
-      entry = {
-        count: 0,
-        lastReset: now,
-        cooldownUntil: 0,
-      };
-      this.limits.set(userId, entry);
-      return entry;
-    }
-
-    // Reset count if minute has passed
-    if (now - entry.lastReset > this.resetInterval) {
-      entry.count = 0;
-      entry.lastReset = now;
-    }
-
-    return entry;
-  }
-
-  // Singleton pattern
   private static instance: RateLimiter;
+  private limits = new Map<number, RateLimitEntry>();
+  private readonly resetInterval = 60 * 1000;
+  private evictTimer: NodeJS.Timeout | null = null;
+
+  private constructor() {
+    this.evictTimer = setInterval(() => this.evictStale(), 10 * 60 * 1000);
+  }
 
   public static getInstance(): RateLimiter {
     if (!RateLimiter.instance) {
       RateLimiter.instance = new RateLimiter();
     }
     return RateLimiter.instance;
+  }
+
+  /**
+   * Atomically checks and consumes a rate limit slot.
+   * Returns true if the request is allowed, false if rate-limited.
+   */
+  public tryConsume(userId: number): boolean {
+    const now = Date.now();
+    const entry = this.limits.get(userId);
+
+    if (!entry) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    if (entry.cooldownUntil > now) {
+      const secondsLeft = Math.ceil((entry.cooldownUntil - now) / 1000);
+      logger.info(`User ${userId} is in cooldown for ${secondsLeft} more seconds`);
+      return false;
+    }
+
+    if (now - entry.lastReset > this.resetInterval) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    if (entry.count >= env.RATE_LIMIT) {
+      this.limits.set(userId, { ...entry, cooldownUntil: now + env.COOLDOWN * 1000 });
+      logger.info(`User ${userId} has exceeded rate limit, cooldown for ${env.COOLDOWN}s`);
+      return false;
+    }
+
+    this.limits.set(userId, { ...entry, count: entry.count + 1 });
+    logger.debug(`User ${userId} has made ${entry.count + 1}/${env.RATE_LIMIT} requests`);
+    return true;
+  }
+
+  private evictStale(): void {
+    const now = Date.now();
+    const staleThreshold = 10 * 60 * 1000;
+    for (const [userId, entry] of this.limits) {
+      if (now - entry.lastReset > staleThreshold && entry.cooldownUntil <= now) {
+        this.limits.delete(userId);
+      }
+    }
+  }
+
+  public stop(): void {
+    if (this.evictTimer) {
+      clearInterval(this.evictTimer);
+      this.evictTimer = null;
+    }
   }
 }

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -37,23 +37,37 @@ export class RateLimiter {
       return true;
     }
 
+    // In cooldown — reject
     if (entry.cooldownUntil > now) {
       const secondsLeft = Math.ceil((entry.cooldownUntil - now) / 1000);
       logger.info(`User ${userId} is in cooldown for ${secondsLeft} more seconds`);
       return false;
     }
 
+    // Cooldown just expired — reset bucket and allow
+    if (entry.cooldownUntil > 0) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    // Window expired — reset and allow
     if (now - entry.lastReset > this.resetInterval) {
       this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
       return true;
     }
 
+    // At limit — enter cooldown, reset count for next window
     if (entry.count >= env.RATE_LIMIT) {
-      this.limits.set(userId, { ...entry, cooldownUntil: now + env.COOLDOWN * 1000 });
+      this.limits.set(userId, {
+        count: 0,
+        lastReset: now,
+        cooldownUntil: now + env.COOLDOWN * 1000,
+      });
       logger.info(`User ${userId} has exceeded rate limit, cooldown for ${env.COOLDOWN}s`);
       return false;
     }
 
+    // Allow and increment
     this.limits.set(userId, { ...entry, count: entry.count + 1 });
     logger.debug(`User ${userId} has made ${entry.count + 1}/${env.RATE_LIMIT} requests`);
     return true;

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -15,6 +15,7 @@ export class RateLimiter {
 
   private constructor() {
     this.evictTimer = setInterval(() => this.evictStale(), 10 * 60 * 1000);
+    this.evictTimer.unref();
   }
 
   public static getInstance(): RateLimiter {

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -2,87 +2,84 @@ import { env } from '../config/env.js';
 import { logger } from './logger.js';
 
 interface RateLimitEntry {
-  count: number;
-  lastReset: number;
-  cooldownUntil: number;
+  readonly count: number;
+  readonly lastReset: number;
+  readonly cooldownUntil: number;
 }
 
+const EVICTION_INTERVAL_MS = 10 * 60 * 1000;
+
 export class RateLimiter {
-  private limits: Map<number, RateLimitEntry> = new Map();
-  private readonly resetInterval = 60 * 1000; // 1 minute in milliseconds
-
-  /**
-   * Checks if a user can make a request
-   * @param userId The user ID to check
-   * @returns Whether the user is allowed to make a request
-   */
-  public canMakeRequest(userId: number): boolean {
-    const now = Date.now();
-    const entry = this.getOrCreateEntry(userId, now);
-
-    // Check if user is in cooldown
-    if (entry.cooldownUntil > now) {
-      const secondsLeft = Math.ceil((entry.cooldownUntil - now) / 1000);
-      logger.info(`User ${userId} is in cooldown for ${secondsLeft} more seconds`);
-      return false;
-    }
-
-    // Check if rate limit exceeded
-    if (entry.count >= env.RATE_LIMIT) {
-      // Set cooldown period
-      entry.cooldownUntil = now + env.COOLDOWN * 1000;
-      logger.info(`User ${userId} has exceeded rate limit, cooldown for ${env.COOLDOWN}s`);
-      return false;
-    }
-
-    // User can make request
-    return true;
-  }
-
-  /**
-   * Records a request for a user
-   * @param userId The user ID making the request
-   */
-  public recordRequest(userId: number): void {
-    const now = Date.now();
-    const entry = this.getOrCreateEntry(userId, now);
-    entry.count++;
-    logger.debug(`User ${userId} has made ${entry.count}/${env.RATE_LIMIT} requests`);
-  }
-
-  /**
-   * Gets or creates a rate limit entry for a user
-   */
-  private getOrCreateEntry(userId: number, now: number): RateLimitEntry {
-    let entry = this.limits.get(userId);
-
-    // Create new entry if none exists
-    if (!entry) {
-      entry = {
-        count: 0,
-        lastReset: now,
-        cooldownUntil: 0,
-      };
-      this.limits.set(userId, entry);
-      return entry;
-    }
-
-    // Reset count if minute has passed
-    if (now - entry.lastReset > this.resetInterval) {
-      entry.count = 0;
-      entry.lastReset = now;
-    }
-
-    return entry;
-  }
-
-  // Singleton pattern
   private static instance: RateLimiter;
+  private limits = new Map<number, RateLimitEntry>();
+  private readonly resetInterval = 60 * 1000;
+  private evictTimer: NodeJS.Timeout | null = null;
+
+  private constructor() {
+    this.evictTimer = setInterval(() => this.evictStale(), EVICTION_INTERVAL_MS);
+    this.evictTimer.unref();
+  }
 
   public static getInstance(): RateLimiter {
     if (!RateLimiter.instance) {
       RateLimiter.instance = new RateLimiter();
     }
     return RateLimiter.instance;
+  }
+
+  public tryConsume(userId: number): boolean {
+    const now = Date.now();
+    const entry = this.limits.get(userId);
+
+    if (!entry) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    if (entry.cooldownUntil > now) {
+      const secondsLeft = Math.ceil((entry.cooldownUntil - now) / 1000);
+      logger.info(`User ${userId} is in cooldown for ${secondsLeft} more seconds`);
+      return false;
+    }
+
+    if (entry.cooldownUntil > 0) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    if (now - entry.lastReset > this.resetInterval) {
+      this.limits.set(userId, { count: 1, lastReset: now, cooldownUntil: 0 });
+      return true;
+    }
+
+    if (entry.count >= env.RATE_LIMIT) {
+      this.limits.set(userId, {
+        count: 0,
+        lastReset: now,
+        cooldownUntil: now + env.COOLDOWN * 1000,
+      });
+      logger.info(`User ${userId} has exceeded rate limit, cooldown for ${env.COOLDOWN}s`);
+      return false;
+    }
+
+    this.limits.set(userId, { ...entry, count: entry.count + 1 });
+    logger.debug(`User ${userId} has made ${entry.count + 1}/${env.RATE_LIMIT} requests`);
+    return true;
+  }
+
+  private evictStale(): void {
+    const now = Date.now();
+    for (const [userId, entry] of this.limits) {
+      if (now - entry.lastReset > EVICTION_INTERVAL_MS && entry.cooldownUntil <= now) {
+        this.limits.delete(userId);
+      }
+    }
+  }
+
+  public stop(): void {
+    if (this.evictTimer) {
+      clearInterval(this.evictTimer);
+      this.evictTimer = null;
+    }
   }
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -34,9 +34,9 @@ export async function withRetry<T>(
   for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
     try {
       return await operation();
-    } catch (error) {
-      lastError = error as Error;
-      const errorMessage = lastError.message || String(error);
+    } catch (caught) {
+      lastError = caught instanceof Error ? caught : new Error(String(caught));
+      const errorMessage = lastError.message;
       const isRetryable = opts.retryableErrors.some((pattern) =>
         typeof pattern === 'string' ? errorMessage.includes(pattern) : pattern.test(errorMessage),
       );

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -20,6 +20,11 @@ const defaultOptions: Required<RetryOptions> = {
     'ECONNREFUSED',
     'socket hang up',
     'getaddrinfo',
+    'HTTP Error 429',
+    'HTTP Error 5',
+    'Read timed out',
+    'urlopen error',
+    'Too Many Requests',
   ],
 };
 
@@ -45,13 +50,14 @@ export async function withRetry<T>(
         throw lastError;
       }
 
+      const jittered = delay * (0.8 + Math.random() * 0.4);
       logger.warn(
         `Operation failed (attempt ${attempt}/${opts.maxAttempts}), retrying in ${
-          delay / 1000
+          Math.round(jittered) / 1000
         }s: ${errorMessage}`,
       );
 
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, jittered));
       delay = Math.min(delay * opts.backoffFactor, opts.maxDelay);
     }
   }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -13,6 +13,9 @@ const defaultOptions: Required<RetryOptions> = {
   initialDelay: 1000,
   maxDelay: 10000,
   backoffFactor: 2,
+  // Note: 429 / "Too Many Requests" are deliberately NOT retried here.
+  // Retrying a rate-limit lengthens the punitive backoff. Per-host cooldown
+  // (utils/hostCooldown) owns 429 handling instead.
   retryableErrors: [
     'Network request',
     'ETIMEDOUT',
@@ -20,6 +23,9 @@ const defaultOptions: Required<RetryOptions> = {
     'ECONNREFUSED',
     'socket hang up',
     'getaddrinfo',
+    'HTTP Error 5',
+    'Read timed out',
+    'urlopen error',
   ],
 };
 
@@ -28,15 +34,18 @@ export async function withRetry<T>(
   options: RetryOptions = {},
 ): Promise<T> {
   const opts = { ...defaultOptions, ...options };
+  if (!Number.isInteger(opts.maxAttempts) || opts.maxAttempts < 1) {
+    throw new RangeError(`maxAttempts must be a positive integer, got: ${opts.maxAttempts}`);
+  }
   let lastError: Error | undefined;
   let delay = opts.initialDelay;
 
   for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
     try {
       return await operation();
-    } catch (error) {
-      lastError = error as Error;
-      const errorMessage = lastError.message || String(error);
+    } catch (caught) {
+      lastError = caught instanceof Error ? caught : new Error(String(caught));
+      const errorMessage = lastError.message;
       const isRetryable = opts.retryableErrors.some((pattern) =>
         typeof pattern === 'string' ? errorMessage.includes(pattern) : pattern.test(errorMessage),
       );
@@ -45,16 +54,17 @@ export async function withRetry<T>(
         throw lastError;
       }
 
+      const jittered = delay * (0.8 + Math.random() * 0.4);
       logger.warn(
         `Operation failed (attempt ${attempt}/${opts.maxAttempts}), retrying in ${
-          delay / 1000
+          Math.round(jittered) / 1000
         }s: ${errorMessage}`,
       );
 
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, jittered));
       delay = Math.min(delay * opts.backoffFactor, opts.maxDelay);
     }
   }
 
-  throw lastError;
+  throw lastError ?? new Error('withRetry: all attempts failed without a captured error');
 }

--- a/src/utils/telegramFlood.ts
+++ b/src/utils/telegramFlood.ts
@@ -1,0 +1,47 @@
+import { logger } from './logger.js';
+
+const DEFAULT_MAX_ATTEMPTS = 2;
+// Small buffer to clear the server's rate-limit window before retrying.
+const RETRY_AFTER_BUFFER_MS = 500;
+
+/**
+ * Reads `retry_after` (seconds) from a Grammy 429 error.
+ * Returns null for any other error shape, so callers know to rethrow.
+ */
+function getTelegramRetryAfter(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const e = error as { error_code?: number; parameters?: { retry_after?: number } };
+  if (e.error_code !== 429) return null;
+  const ra = e.parameters?.retry_after;
+  return typeof ra === 'number' && ra > 0 ? ra : null;
+}
+
+/**
+ * Runs a Telegram send operation, retrying once on HTTP 429 by sleeping
+ * exactly the server-reported `retry_after` (plus a small buffer).
+ * Non-429 errors propagate immediately — this is not a generic retry layer.
+ */
+export async function withTelegramFlood<T>(
+  operation: () => Promise<T>,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+): Promise<T> {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError(`maxAttempts must be a positive integer, got: ${maxAttempts}`);
+  }
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const retryAfter = getTelegramRetryAfter(error);
+      if (retryAfter === null || attempt === maxAttempts) throw error;
+      const sleepMs = retryAfter * 1000 + RETRY_AFTER_BUFFER_MS;
+      logger.warn(
+        `Telegram 429 — waiting ${retryAfter}s before retry (attempt ${attempt}/${maxAttempts})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, sleepMs));
+    }
+  }
+  throw lastError ?? new Error('withTelegramFlood: all attempts failed without a captured error');
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,60 +1,38 @@
 import { env } from '../config/env.js';
 
 /**
- * Validates if the given string is a valid URL
- * @param url - The URL string to validate
- * @returns boolean indicating if the URL is valid
+ * Checks if a hostname matches a domain pattern.
+ * Properly handles full domain matching to prevent partial matches
+ * (e.g. 'hehx.com' should not match 'x.com').
  */
-export const isValidUrl = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
- * Checks if a hostname matches a domain pattern
- * This properly handles full domain matching to prevent partial matches
- * (e.g. 'hehx.com' should not match 'x.com')
- * @param hostname - The hostname to check
- * @param domain - The domain pattern to match against
- * @returns Whether the hostname matches the domain
- */
-const isDomainMatch = (hostname: string, domain: string): boolean => {
-  // Exact match
+export const isDomainMatch = (hostname: string, domain: string): boolean => {
   if (hostname === domain) return true;
-
-  // Subdomain match (e.g. sub.example.com matches example.com)
   if (hostname.endsWith(`.${domain}`)) return true;
-
   return false;
 };
 
 /**
- * Checks if the URL is from a supported media platform
- * @param url - The URL to check
- * @returns boolean indicating if the URL is from a supported platform
+ * Checks if a string is a valid URL from a supported platform.
+ * Combines URL parsing, protocol validation, and domain matching in a single pass.
+ * Only allows http/https protocols.
  */
-export const isSupportedPlatform = (url: string): boolean => {
+export const isSupportedUrl = (url: string): boolean => {
   try {
-    const { hostname } = new URL(url);
-    return env.SUPPORTED_DOMAINS.some((domain) => isDomainMatch(hostname, domain));
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    return env.SUPPORTED_DOMAINS.some((domain) => isDomainMatch(parsed.hostname, domain));
   } catch {
     return false;
   }
 };
 
-/**
- * Gets a formatted list of supported platforms for display
- * @returns string of supported platforms
- */
-export const getSupportedPlatforms = (): string => {
-  const platforms = env.SUPPORTED_DOMAINS.map((domain) => {
+// Compute once at module load since SUPPORTED_DOMAINS is immutable
+const supportedPlatformsDisplay = ((): string => {
+  const seen = new Set<string>();
+  return env.SUPPORTED_DOMAINS.map((domain) => {
     switch (domain) {
       case 'youtu.be':
-        return null; // Skip alternate YouTube domain
+        return null;
       case 'youtube.com':
         return 'YouTube';
       case 'vimeo.com':
@@ -74,8 +52,12 @@ export const getSupportedPlatforms = (): string => {
         return domain.split('.')[0].charAt(0).toUpperCase() + domain.split('.')[0].slice(1);
     }
   })
-    .filter((platform): platform is string => platform !== null)
+    .filter((platform): platform is string => {
+      if (platform === null || seen.has(platform)) return false;
+      seen.add(platform);
+      return true;
+    })
     .join(', ');
+})();
 
-  return platforms;
-};
+export const getSupportedPlatforms = (): string => supportedPlatformsDisplay;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,14 +1,5 @@
 import { env } from '../config/env.js';
 
-export const isValidUrl = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 /**
  * Checks if a hostname matches a domain pattern.
  * Properly handles full domain matching to prevent partial matches
@@ -21,10 +12,11 @@ export const isDomainMatch = (hostname: string, domain: string): boolean => {
 };
 
 /**
- * Checks if the URL is from a supported media platform.
+ * Checks if a string is a valid URL from a supported platform.
+ * Combines URL parsing, protocol validation, and domain matching in a single pass.
  * Only allows http/https protocols.
  */
-export const isSupportedPlatform = (url: string): boolean => {
+export const isSupportedUrl = (url: string): boolean => {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,10 +1,5 @@
 import { env } from '../config/env.js';
 
-/**
- * Validates if the given string is a valid URL
- * @param url - The URL string to validate
- * @returns boolean indicating if the URL is valid
- */
 export const isValidUrl = (url: string): boolean => {
   try {
     new URL(url);
@@ -15,46 +10,37 @@ export const isValidUrl = (url: string): boolean => {
 };
 
 /**
- * Checks if a hostname matches a domain pattern
- * This properly handles full domain matching to prevent partial matches
- * (e.g. 'hehx.com' should not match 'x.com')
- * @param hostname - The hostname to check
- * @param domain - The domain pattern to match against
- * @returns Whether the hostname matches the domain
+ * Checks if a hostname matches a domain pattern.
+ * Properly handles full domain matching to prevent partial matches
+ * (e.g. 'hehx.com' should not match 'x.com').
  */
-const isDomainMatch = (hostname: string, domain: string): boolean => {
-  // Exact match
+export const isDomainMatch = (hostname: string, domain: string): boolean => {
   if (hostname === domain) return true;
-
-  // Subdomain match (e.g. sub.example.com matches example.com)
   if (hostname.endsWith(`.${domain}`)) return true;
-
   return false;
 };
 
 /**
- * Checks if the URL is from a supported media platform
- * @param url - The URL to check
- * @returns boolean indicating if the URL is from a supported platform
+ * Checks if the URL is from a supported media platform.
+ * Only allows http/https protocols.
  */
 export const isSupportedPlatform = (url: string): boolean => {
   try {
-    const { hostname } = new URL(url);
-    return env.SUPPORTED_DOMAINS.some((domain) => isDomainMatch(hostname, domain));
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    return env.SUPPORTED_DOMAINS.some((domain) => isDomainMatch(parsed.hostname, domain));
   } catch {
     return false;
   }
 };
 
-/**
- * Gets a formatted list of supported platforms for display
- * @returns string of supported platforms
- */
-export const getSupportedPlatforms = (): string => {
-  const platforms = env.SUPPORTED_DOMAINS.map((domain) => {
+// Compute once at module load since SUPPORTED_DOMAINS is immutable
+const supportedPlatformsDisplay = ((): string => {
+  const seen = new Set<string>();
+  return env.SUPPORTED_DOMAINS.map((domain) => {
     switch (domain) {
       case 'youtu.be':
-        return null; // Skip alternate YouTube domain
+        return null;
       case 'youtube.com':
         return 'YouTube';
       case 'vimeo.com':
@@ -74,8 +60,12 @@ export const getSupportedPlatforms = (): string => {
         return domain.split('.')[0].charAt(0).toUpperCase() + domain.split('.')[0].slice(1);
     }
   })
-    .filter((platform): platform is string => platform !== null)
+    .filter((platform): platform is string => {
+      if (platform === null || seen.has(platform)) return false;
+      seen.add(platform);
+      return true;
+    })
     .join(', ');
+})();
 
-  return platforms;
-};
+export const getSupportedPlatforms = (): string => supportedPlatformsDisplay;

--- a/src/utils/urlNormalize.ts
+++ b/src/utils/urlNormalize.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalizes a URL to a stable cache key by stripping the protocol,
+ * www prefix, and everything from the first '&' onward. The content
+ * identifier on supported platforms is always before the first '&'.
+ */
+export function normalizeUrl(url: string): string {
+  const ampIndex = url.indexOf('&');
+  const cleaned = ampIndex >= 0 ? url.slice(0, ampIndex) : url;
+  return cleaned.replace(/^https?:\/\/(www\.)?/, '');
+}

--- a/src/utils/urlNormalize.ts
+++ b/src/utils/urlNormalize.ts
@@ -1,0 +1,60 @@
+// Query params that never identify content — stripped so they don't fragment
+// the cache. Everything else is kept (sorted) so distinct content under the
+// same path (e.g. facebook /watch/?v=ID) doesn't collide to one key.
+const TRACKING_PARAMS = new Set([
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'fbclid',
+  'gclid',
+  'igsh',
+  'igshid',
+  'si',
+  'feature',
+]);
+
+/**
+ * Normalizes a URL to a stable cache key.
+ * - Strips protocol, www., fragments, trailing slashes
+ * - Canonicalizes domain aliases (youtu.be→youtube.com, x.com→twitter.com)
+ * - For YouTube, keeps only ?v=ID
+ * - Drops tracking query params; keeps the rest (sorted) because content can
+ *   live in the query string (e.g. facebook /watch/?v=ID)
+ */
+export function normalizeUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Upstream validation should prevent this, but fall back to the raw
+    // string so callers (cache keys, in-flight map) don't see exceptions.
+    return url;
+  }
+  let host = parsed.hostname.replace(/^www\./, '');
+  const path = parsed.pathname.replace(/\/+$/, '');
+
+  // youtu.be/ID → youtube.com/watch?v=ID
+  if (host === 'youtu.be') {
+    return `youtube.com/watch?v=${path.slice(1)}`;
+  }
+
+  // youtube.com/watch?v=ID — keep only the video id.
+  if (host === 'youtube.com') {
+    const v = parsed.searchParams.get('v');
+    if (v) return `youtube.com/watch?v=${v}`;
+  }
+
+  // x.com → twitter.com
+  if (host === 'x.com') host = 'twitter.com';
+
+  // Keep content-identifying query params (drop tracking noise), sorted for a
+  // stable key, so e.g. facebook /watch/?v=1 and ?v=2 stay distinct.
+  const params = [...parsed.searchParams.entries()]
+    .filter(([key]) => !TRACKING_PARAMS.has(key.toLowerCase()))
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  const query = params.length ? `?${params.map(([k, v]) => `${k}=${v}`).join('&')}` : '';
+
+  return `${host}${path}${query}`;
+}

--- a/test/caption.test.ts
+++ b/test/caption.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSingleCaption, buildGroupCaption, type CaptionMediaItem } from '../src/utils/caption.js';
+
+const TELEGRAM_CAPTION_MAX = 1024;
+const videoItem: CaptionMediaItem = { isVideo: true, streamInfo: 'h264 1920x1080', fileSizeMB: '12.3' };
+
+test('buildSingleCaption fits within the cap and links the URL for normal input', () => {
+  const cap = buildSingleCaption('A nice video', 'https://youtube.com/watch?v=abc', videoItem);
+  assert.ok(cap.length <= TELEGRAM_CAPTION_MAX);
+  assert.ok(cap.includes('watch?v=abc'));
+});
+
+test('buildSingleCaption stays within the cap for very long titles', () => {
+  const cap = buildSingleCaption('x'.repeat(5000), 'https://youtube.com/watch?v=abc', videoItem);
+  assert.ok(cap.length <= TELEGRAM_CAPTION_MAX, `len=${cap.length}`);
+});
+
+test('buildSingleCaption stays within the cap for pathologically long URLs', () => {
+  const longUrl = 'https://example.com/' + 'a'.repeat(2000);
+  const cap = buildSingleCaption('title', longUrl, videoItem);
+  assert.ok(cap.length <= TELEGRAM_CAPTION_MAX, `len=${cap.length}`);
+});
+
+test('buildGroupCaption stays within the cap for first and subsequent chunks', () => {
+  const chunk: CaptionMediaItem[] = [
+    { isVideo: false, streamInfo: 'jpeg 800x600', fileSizeMB: '1.0' },
+    { isVideo: true, streamInfo: 'h264 1920x1080', fileSizeMB: '5.0' },
+  ];
+  const first = buildGroupCaption('x'.repeat(5000), 'https://youtube.com/watch?v=abc', chunk, true);
+  assert.ok(first.length <= TELEGRAM_CAPTION_MAX, `len=${first.length}`);
+  const rest = buildGroupCaption('t', 'https://youtube.com/watch?v=abc', chunk, false);
+  assert.ok(rest.length <= TELEGRAM_CAPTION_MAX);
+});
+
+test('buildGroupCaption summarizes image/video counts and total size', () => {
+  const chunk: CaptionMediaItem[] = [
+    { isVideo: false, streamInfo: 'jpeg 800x600', fileSizeMB: '1.0' },
+    { isVideo: false, streamInfo: 'jpeg 800x600', fileSizeMB: '2.0' },
+    { isVideo: true, streamInfo: 'h264 1920x1080', fileSizeMB: '5.0' },
+  ];
+  const cap = buildGroupCaption('title', 'https://youtube.com/watch?v=abc', chunk, true);
+  assert.ok(cap.includes('2 jpeg images'), cap);
+  assert.ok(cap.includes('1 h264 video'), cap);
+  assert.ok(cap.includes('MB total'), cap);
+});
+
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+test('buildSingleCaption never emits a lone surrogate from a long emoji title', () => {
+  const cap = buildSingleCaption('😀'.repeat(2000), 'https://youtube.com/watch?v=abc', videoItem);
+  assert.ok(cap.length <= TELEGRAM_CAPTION_MAX, `len=${cap.length}`);
+  assert.ok(!LONE_SURROGATE.test(cap), 'caption must be well-formed UTF-16 (no split surrogate pair)');
+});
+
+test('buildSingleCaption flattens newlines so the MarkdownV2 link label is single-line', () => {
+  const cap = buildSingleCaption(
+    'line one\nline two\n\n\nline three',
+    'https://youtube.com/watch?v=abc',
+    videoItem,
+  );
+  const linkSep = cap.indexOf('](');
+  assert.notEqual(linkSep, -1, `expected a markdown link delimiter in: ${cap}`);
+  const label = cap.slice(0, linkSep);
+  assert.ok(!label.includes('\n'), `link label must not contain a newline: ${JSON.stringify(label)}`);
+});

--- a/test/concurrency.test.ts
+++ b/test/concurrency.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Semaphore } from '../src/utils/concurrency.js';
+
+test('Semaphore caps concurrency and runs every task', async () => {
+  const sem = new Semaphore(2);
+  let active = 0;
+  let maxActive = 0;
+  const task = async (): Promise<string> => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((r) => setTimeout(r, 5));
+    active--;
+    return 'done';
+  };
+  const results = await Promise.all([1, 2, 3, 4, 5].map(() => sem.run(task)));
+  assert.equal(results.length, 5);
+  assert.ok(results.every((r) => r === 'done'));
+  assert.equal(maxActive, 2, `maxActive=${maxActive}`);
+});
+
+test('Semaphore rejects non-integer and non-positive sizes', () => {
+  assert.throws(() => new Semaphore(0), RangeError);
+  assert.throws(() => new Semaphore(-1), RangeError);
+  assert.throws(() => new Semaphore(2.5), RangeError);
+  assert.throws(() => new Semaphore(Number.NaN), RangeError);
+  assert.doesNotThrow(() => new Semaphore(1));
+});
+
+test('Semaphore propagates task errors and still releases the slot', async () => {
+  const sem = new Semaphore(1);
+  await assert.rejects(
+    () => sem.run(async () => { throw new Error('boom'); }),
+    /boom/,
+  );
+  assert.equal(await sem.run(async () => 'ok'), 'ok');
+});

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { safeExec } from '../src/utils/exec.js';
+
+test('safeExec runs a command and captures stdout (no shell)', async () => {
+  const { stdout } = await safeExec(process.execPath, ['-e', 'process.stdout.write("ok")']);
+  assert.equal(stdout, 'ok');
+});
+
+test('safeExec rejects invalid timeout and maxBuffer', async () => {
+  await assert.rejects(() => safeExec('true', [], { timeout: 0 }), RangeError);
+  await assert.rejects(() => safeExec('true', [], { timeout: -5 }), RangeError);
+  await assert.rejects(() => safeExec('true', [], { maxBuffer: 0 }), RangeError);
+  await assert.rejects(() => safeExec('true', [], { timeout: Number.NaN }), RangeError);
+});

--- a/test/hostCooldown.test.ts
+++ b/test/hostCooldown.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isRateLimitError,
+  applyRateLimitFromError,
+  getCooldownRemainingMs,
+  computeCooldownTarget,
+} from '../src/utils/hostCooldown.js';
+
+test('isRateLimitError detects known 429 signals', () => {
+  assert.ok(isRateLimitError(new Error('HTTP Error 429: Too Many Requests')));
+  assert.ok(isRateLimitError('Waiting until 23:59:59'));
+  assert.ok(isRateLimitError(new Error('got 429 back')));
+  assert.ok(!isRateLimitError(new Error('connection refused')));
+});
+
+test('applyRateLimitFromError sets a bounded, positive cooldown', () => {
+  const host = 'cooldown-test-default.example';
+  const secs = applyRateLimitFromError(host, 'some 429 with no timestamp');
+  assert.ok(secs > 0 && secs <= 30 * 60, `secs=${secs}`);
+  assert.ok(getCooldownRemainingMs(host) > 0);
+});
+
+test('getCooldownRemainingMs returns 0 for an unknown host', () => {
+  assert.equal(getCooldownRemainingMs('never-seen.example'), 0);
+});
+
+test('computeCooldownTarget caps a far-future wait at 30 minutes (deterministic clock)', () => {
+  // From 00:00:00 UTC, "Waiting until 23:59:59" is ~24h away → capped to 30 min.
+  const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+  assert.equal(computeCooldownTarget('Waiting until 23:59:59', now) - now, 30 * 60 * 1000);
+});
+
+test('computeCooldownTarget falls back to the default cooldown without a timestamp', () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  assert.equal(computeCooldownTarget('HTTP Error 429: Too Many Requests', now) - now, 90 * 1000);
+});

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { escapeMarkdownV2, escapeMarkdownV2Url, normalizeLineBreaks } from '../src/utils/markdown.js';
+
+test('escapeMarkdownV2 prefixes every MarkdownV2 special char with a backslash', () => {
+  const special = ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\'];
+  for (const ch of special) {
+    assert.equal(escapeMarkdownV2(ch), '\\' + ch, `char ${JSON.stringify(ch)}`);
+  }
+  assert.equal(escapeMarkdownV2('plain text'), 'plain text');
+  assert.equal(escapeMarkdownV2('a.b_c'), 'a\\.b\\_c');
+});
+
+test('escapeMarkdownV2Url escapes only ) and backslash', () => {
+  assert.equal(escapeMarkdownV2Url(')'), '\\)');
+  assert.equal(escapeMarkdownV2Url('\\'), '\\\\');
+  assert.equal(escapeMarkdownV2Url('('), '('); // ( is not escaped inside a link URL
+  assert.equal(escapeMarkdownV2Url('https://ex.com/a.b_c-d'), 'https://ex.com/a.b_c-d');
+});
+
+test('normalizeLineBreaks normalizes CRLF, blank lines and 3+ newlines', () => {
+  assert.equal(normalizeLineBreaks('a\r\nb'), 'a\nb');
+  assert.equal(normalizeLineBreaks('a\n\n\n\nb'), 'a\n\nb');
+  assert.equal(normalizeLineBreaks('  \n a \n  '), 'a');
+  assert.equal(normalizeLineBreaks('a\n\nb'), 'a\n\nb'); // legitimate paragraph break preserved
+});

--- a/test/mediaProbe.test.ts
+++ b/test/mediaProbe.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractStreamInfo, type FFprobeStream } from '../src/services/mediaProbe.js';
+
+test('extractStreamInfo summarizes a video stream with dimensions and bitrate', () => {
+  const streams: FFprobeStream[] = [
+    { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, bit_rate: '2500000' },
+  ];
+  const r = extractStreamInfo(streams, true);
+  assert.equal(r.width, 1920);
+  assert.equal(r.height, 1080);
+  assert.ok(r.info.includes('h264 1920x1080'));
+  assert.ok(r.info.includes('2500kbps'));
+});
+
+test('extractStreamInfo omits bitrate for still images (isVideo=false)', () => {
+  const streams: FFprobeStream[] = [
+    { codec_type: 'video', codec_name: 'mjpeg', width: 800, height: 600, bit_rate: '999999' },
+  ];
+  const r = extractStreamInfo(streams, false);
+  assert.equal(r.info, 'mjpeg 800x600');
+});
+
+test('extractStreamInfo describes audio with bitrate and sample rate', () => {
+  const streams: FFprobeStream[] = [
+    { codec_type: 'audio', codec_name: 'opus', bit_rate: '128000', sample_rate: '48000' },
+  ];
+  const r = extractStreamInfo(streams, false);
+  assert.equal(r.info, 'opus 128kbps 48kHz');
+  assert.equal(r.width, undefined);
+});
+
+test('extractStreamInfo falls back to ? for missing dimensions and uses format bitrate', () => {
+  const streams: FFprobeStream[] = [{ codec_type: 'video', codec_name: 'h264' }];
+  const r = extractStreamInfo(streams, true, { bit_rate: '1000000' });
+  assert.ok(r.info.includes('h264 ?x?'));
+  assert.ok(r.info.includes('1000kbps'));
+});

--- a/test/pathSafety.test.ts
+++ b/test/pathSafety.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { assertSafePath } from '../src/utils/pathSafety.js';
+
+test('assertSafePath returns the resolved path for files strictly inside base', () => {
+  const base = resolve('/tmp/tgmr-base');
+  assert.equal(
+    assertSafePath('/tmp/tgmr-base/sub/file.mp4', base),
+    resolve('/tmp/tgmr-base/sub/file.mp4'),
+  );
+});
+
+test('assertSafePath rejects the base itself, traversal, and outside paths', () => {
+  const base = '/tmp/tgmr-base';
+  assert.throws(() => assertSafePath('/tmp/tgmr-base', base), /Path traversal/);
+  assert.throws(() => assertSafePath('/tmp/tgmr-base/../etc/passwd', base), /Path traversal/);
+  assert.throws(() => assertSafePath('/etc/passwd', base), /Path traversal/);
+});

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { RateLimiter } from '../src/utils/rateLimit.js';
+import { env } from '../src/config/env.js';
+
+// Each test uses a unique user id because RateLimiter is a process-wide singleton.
+
+test('tryConsume allows up to RATE_LIMIT requests, then blocks within the window', () => {
+  const rl = RateLimiter.getInstance();
+  const user = 900001;
+  for (let i = 0; i < env.RATE_LIMIT; i++) {
+    assert.equal(rl.tryConsume(user), true, `request ${i + 1} should pass`);
+  }
+  assert.equal(rl.tryConsume(user), false, 'request over the limit should be blocked');
+});
+
+test('tryConsume tracks users independently', () => {
+  const rl = RateLimiter.getInstance();
+  assert.equal(rl.tryConsume(900002), true);
+  assert.equal(rl.tryConsume(900003), true);
+});
+
+test('stop() clears the eviction timer and is idempotent', () => {
+  const rl = RateLimiter.getInstance();
+  assert.doesNotThrow(() => rl.stop());
+  assert.doesNotThrow(() => rl.stop());
+});

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withRetry } from '../src/utils/retry.js';
+
+test('withRetry returns immediately on success', async () => {
+  let calls = 0;
+  const r = await withRetry(async () => {
+    calls++;
+    return 42;
+  });
+  assert.equal(r, 42);
+  assert.equal(calls, 1);
+});
+
+test('withRetry retries retryable errors then succeeds', async () => {
+  let calls = 0;
+  const r = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 2) throw new Error('ETIMEDOUT while connecting');
+      return 'ok';
+    },
+    { maxAttempts: 3, initialDelay: 1, maxDelay: 2 },
+  );
+  assert.equal(r, 'ok');
+  assert.equal(calls, 2);
+});
+
+test('withRetry does not retry non-retryable errors', async () => {
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error('fatal: bad input');
+        },
+        { maxAttempts: 3, initialDelay: 1 },
+      ),
+    /fatal/,
+  );
+  assert.equal(calls, 1);
+});
+
+test('withRetry throws after exhausting attempts', async () => {
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error('ECONNRESET');
+        },
+        { maxAttempts: 2, initialDelay: 1 },
+      ),
+    /ECONNRESET/,
+  );
+  assert.equal(calls, 2);
+});
+
+test('withRetry rejects invalid maxAttempts', async () => {
+  await assert.rejects(() => withRetry(async () => 1, { maxAttempts: 0 }), RangeError);
+  await assert.rejects(() => withRetry(async () => 1, { maxAttempts: 1.5 }), RangeError);
+});

--- a/test/telegramFlood.test.ts
+++ b/test/telegramFlood.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withTelegramFlood } from '../src/utils/telegramFlood.js';
+
+test('withTelegramFlood returns on success', async () => {
+  let calls = 0;
+  const r = await withTelegramFlood(async () => {
+    calls++;
+    return 'sent';
+  });
+  assert.equal(r, 'sent');
+  assert.equal(calls, 1);
+});
+
+test('withTelegramFlood propagates non-429 errors immediately', async () => {
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      withTelegramFlood(async () => {
+        calls++;
+        throw new Error('400 bad request');
+      }),
+    /400/,
+  );
+  assert.equal(calls, 1);
+});
+
+test('withTelegramFlood retries once on 429 honoring retry_after', async () => {
+  let calls = 0;
+  const start = Date.now();
+  const r = await withTelegramFlood(async () => {
+    calls++;
+    if (calls < 2) throw { error_code: 429, parameters: { retry_after: 0.001 } };
+    return 'sent';
+  }, 2);
+  assert.equal(r, 'sent');
+  assert.equal(calls, 2);
+  // Prove it actually waited (retry_after + the 500ms buffer) rather than
+  // retrying immediately — otherwise the delay contract is untested.
+  assert.ok(Date.now() - start >= 450, `retried after only ${Date.now() - start}ms`);
+});
+
+test('withTelegramFlood rejects invalid maxAttempts', async () => {
+  await assert.rejects(() => withTelegramFlood(async () => 1, 0), RangeError);
+  await assert.rejects(() => withTelegramFlood(async () => 1, 2.5), RangeError);
+});

--- a/test/urlNormalize.test.ts
+++ b/test/urlNormalize.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeUrl } from '../src/utils/urlNormalize.js';
+
+test('normalizeUrl canonicalizes youtu.be and youtube watch URLs', () => {
+  assert.equal(normalizeUrl('https://youtu.be/abc123'), 'youtube.com/watch?v=abc123');
+  assert.equal(normalizeUrl('https://www.youtube.com/watch?v=XYZ&t=10s'), 'youtube.com/watch?v=XYZ');
+});
+
+test('normalizeUrl maps x.com to twitter.com and strips www, trailing slash and query', () => {
+  assert.equal(normalizeUrl('https://x.com/user/status/1'), 'twitter.com/user/status/1');
+  assert.equal(normalizeUrl('https://www.instagram.com/p/ABC/'), 'instagram.com/p/ABC');
+  assert.equal(normalizeUrl('https://instagram.com/p/ABC?igsh=xyz'), 'instagram.com/p/ABC');
+});
+
+test('normalizeUrl returns the raw string for unparseable input', () => {
+  assert.equal(normalizeUrl('not a url'), 'not a url');
+});
+
+test('normalizeUrl does not collide distinct YouTube videos', () => {
+  assert.notEqual(
+    normalizeUrl('https://youtube.com/watch?v=AAA'),
+    normalizeUrl('https://youtube.com/watch?v=BBB'),
+  );
+});
+
+test('normalizeUrl keeps content-identifying query params so distinct content does not collide', () => {
+  assert.equal(normalizeUrl('https://www.facebook.com/watch/?v=123'), 'facebook.com/watch?v=123');
+  assert.notEqual(
+    normalizeUrl('https://www.facebook.com/watch/?v=1'),
+    normalizeUrl('https://www.facebook.com/watch/?v=2'),
+  );
+});
+
+test('normalizeUrl strips tracking params and sorts the rest for a stable key', () => {
+  assert.equal(
+    normalizeUrl('https://example.com/p?b=2&a=1&utm_source=x&fbclid=y'),
+    'example.com/p?a=1&b=2',
+  );
+  assert.equal(
+    normalizeUrl('https://example.com/p?a=1&b=2'),
+    normalizeUrl('https://example.com/p?b=2&a=1'),
+  );
+});

--- a/test/versionCheck.test.ts
+++ b/test/versionCheck.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { compareVersions } from '../src/services/versionCheck.js';
+
+test('compareVersions compares numerically component-by-component', () => {
+  // yt-dlp CalVer: component 1 (04 vs 3) decides → 4 > 3
+  assert.ok(compareVersions('2026.04.10.235301', '2026.3.17') > 0);
+  assert.ok(compareVersions('1.2.4', '1.2.3') > 0);
+  assert.ok(compareVersions('1.2.3', '1.2.4') < 0);
+  assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
+});
+
+test('compareVersions ignores trailing non-numeric/dev segments and missing components', () => {
+  assert.equal(compareVersions('1.2.3.dev0', '1.2.3'), 0);
+  assert.equal(compareVersions('1.2', '1.2.0'), 0);
+  assert.ok(compareVersions('1.2.1', '1.2') > 0);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist-test"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist", "dist-test"]
+}


### PR DESCRIPTION
## Summary

A comprehensive **security, performance, reliability, and feature overhaul** of the bot, rebased onto current `main`. All external-tool execution is now shell-free and path-validated; the download pipeline is restructured around a gallery-dl (images) / yt-dlp (videos) split with caching, per-host cooldowns, and concurrency limits; a `node:test` unit suite and CI gating were added; and the whole branch was hardened through multiple rounds of automated review.

### Security
- **No shell execution** — every `yt-dlp` / `gallery-dl` / `ffmpeg` / `ffprobe` call goes through one `safeExec` wrapper (`execFile`, arguments as arrays), so command injection is structurally impossible. `safeExec` also validates `timeout`/`maxBuffer` so a stalled subprocess can't pin a slot.
- **Path-traversal prevention** — every filesystem op on a tool-produced path (read, `unlink`, `ffprobe`, send, thumbnail, cleanup) is guarded by `assertSafePath` (cross-platform `path.relative` check).
- **`BOT_TOKEN` validated at startup** (no `as string` hiding `undefined`).
- **No secret/PII leakage** — cookie/header values are never logged; INFO-level URL logging strips the query string; user-facing errors are generic.
- **Untyped external JSON is coerced** before use; all `JSON.parse` of tool output is guarded; codec fields are JSON-encoded in the yt-dlp print template.
- **Container hardening** — `no-new-privileges`, `cap_drop: ALL`, `pids_limit`, `noexec,nosuid` tmpfs.

### Performance
- **One metadata call** — `mediaInfo` is fetched once and threaded into `download()` (no re-fetch).
- **Concurrency limits** — a counting `Semaphore` caps concurrent downloads (5) and probes (10); the download slot is held **only around the actual download**, so duplicate-URL requests and cache hits don't starve it.
- **Download cache + in-flight dedup** — identical URLs share a single download; results are cached (7-day TTL, **byte-bounded** with oldest-non-in-use eviction) and re-sent on repeat. Cache keys drop tracking params but keep content-identifying ones (sorted), so distinct content (e.g. `facebook.com/watch/?v=ID`) doesn't collide.
- **Per-host 429 cooldown** — a rate-limited host short-circuits with an accurate retry hint (armed from both info-fetch and download 429s).

### Reliability & correctness
- **Atomic rate limiter** (no TOCTOU), periodic eviction, immutable updates.
- **Graceful shutdown** — one-shot, clears every timer (cleanup, rate-limit, version-check, cache-evict, permission-prune), hard-exit backstop.
- **Telegram protocol** — honours `retry_after` on 429 (no split/duplicate albums); albums chunk to ≤10 and a lone trailing item (10n+1) is sent via the single-media path; partial-album delivery is reported honestly.
- **Caption safety** — bounded to Telegram's 1024-char cap, MarkdownV2-escaped, single-line link labels, code-point-safe truncation (no split emoji → no 400).
- **Cache/cleanup consistency** — files are stamped at download time (`--no-mtime`); the periodic sweep skips live-cache files, tolerates per-file `ENOENT`, and reaps orphans; partial downloads and derived `.jpg/.webp/.png` thumbnail sidecars are cleaned on failure.
- **Per-video thumbnails** are downscaled to Telegram's ≤320px/<200KB JPEG constraint (omitted if scaling fails) so an oversized thumbnail can't fail the whole video send.
- **Resilient retries** — `withRetry`/`withTelegramFlood` validate `maxAttempts` and never `throw undefined`; 429 is deliberately not retried (host-cooldown owns it).

### Features (added across the branch)
- gallery-dl (images) / yt-dlp (videos) split via a unified `SITES` registry; mixed carousels deliver the images even if all videos fail; per-request gallery-dl filename prefix prevents cross-URL disk collisions.
- `+info` flag (standalone trailing token) for a detailed caption (codec, dimensions, size).
- Per-site browser-fingerprint headers (keep cookie sessions fresh) and Instagram 429-wave mitigations.
- Periodic tool-version check (gallery-dl/yt-dlp vs PyPI) and a `BUILD_DATE` Docker arg that busts the pipx layer so the **daily CI build pulls the latest tools without manual pin bumps**.

### Code quality
- Focused utility modules: `exec`, `pathSafety`, `markdown`, `caption`, `concurrency`, `chatAction`, `hostCooldown`, `telegramFlood`, `urlNormalize`.
- The `handleMessage` god-function is decomposed into a clear pipeline (`processMediaRequest` → `runDownloadPipeline` → `buildMediaItems` → `sendResult` → cleanup).
- `escapeMarkdownV2` extracted (was copy-pasted); dead code removed; immutable update patterns throughout; structured logger.

### Infrastructure
- `Dockerfile` on `node:slim` with Yarn provided explicitly (current `node:slim` no longer bundles it), minimum tool versions pinned, `.dockerignore` added.
- **CI** (`docker-build.yml`): a `verify` job runs lint + typecheck + **tests** on every push and PR (gating PRs); the image is built/published on push, manual dispatch, and a daily schedule that always rebuilds for tool freshness — never from a PR.

### Testing
- A `node --test` unit suite (**zero new runtime deps**; compiled via `tsconfig.test.json` to `dist-test`) covering the pure logic: caption cap/escaping/truncation/surrogate-safety, URL normalization (incl. query-collision), path safety, concurrency (incl. integer-size guard), retry/flood `maxAttempts` guards, rate limiting, host cooldowns, `safeExec` validation, version comparison, and stream-info formatting. **45 tests.**
- The live download pipeline (network + external tools) is validated manually — see the test plan.

### Review process
This branch was finalized through several rounds of automated review — five lens-specialised Claude reviewers (security, correctness/concurrency, resource/reliability, Telegram-protocol, types/quality) plus Codex (gpt-5.5) as an independent reviewer — each round adversarially verifying the prior round's fixes before re-scanning. Review converged with no substantive issues outstanding.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `yarn lint` passes
- [x] `yarn test` passes (45/45)
- [x] `docker build` succeeds; container boots, connects to Telegram (`getMe`), starts polling, clean logs, exits cleanly on SIGTERM
- [ ] YouTube link → single video reply (one metadata call in logs)
- [ ] Instagram post → images via gallery-dl (path-validated); carousel with a video item
- [ ] `+info` → caption shows codec/dimensions/size within the 1024 cap
- [ ] 6+ rapid requests → rate limit kicks in
- [ ] 11+-item album → delivered as 10 + 1 (no media-group error)

## Known limitations
- Partial files from a hard-killed (timeout) subprocess are reaped by the periodic sweep + startup `TMP_DIR` wipe, not immediately.
- Live download-pipeline integration is validated manually (external tools/network), not in unit tests.
- tmpfs size and `MAX_FILE_SIZE` / album / concurrency limits are tunable in `docker-compose.yml`; the defaults assume typical media sizes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-site cookie/header routing, safer URL normalization, improved caption building, thumbnail downscaling, chat-action keepalive, semaphore utility, host cooldowns, Telegram-flood-aware retry helper, and startup version checks with graceful shutdown.

* **Improvements**
  * Robust media download pipeline with caching, concurrency coordination, safer temp-file handling, consolidated cleanup, structured logging, and stricter container build/run defaults.

* **Chores**
  * Added .env example, .dockerignore, CI verify step, test runner script, many tests, and ignore updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/tgmr/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->