### PR TITLE
chore(deps): bump transitive picomatch to 2.3.2 / 4.0.4 (CVE-2026-33672)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -752,14 +752,14 @@ path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Resolves Dependabot security alerts **#22** and **#25** (GHSA-3v7f-55p6-f55p / CVE-2026-33672 — incorrect glob matching via method injection in POSIX character classes).

## What
Lockfile-only re-resolution of the transitive `picomatch` dependency within its existing semver ranges:
- `picomatch@^2.0.4, ^2.2.1`: **2.3.1 → 2.3.2** (fixes alert #25, `< 2.3.2`)
- `picomatch@^4.0.3`: **4.0.3 → 4.0.4** (fixes alert #22, `>= 4.0.0, < 4.0.4`)

## Risk
**Dev-only.** picomatch is pulled transitively by dev tooling only:
- 2.x: `nodemon → chokidar → anymatch/readdirp`
- 4.x: `@typescript-eslint/parser → typescript-estree → tinyglobby`

It is **not** in the production runtime image (which installs only `grammy`). Both are patch bumps with no API changes.

## Validation
`yarn install --frozen-lockfile`, `yarn lint`, `yarn build`, `yarn test` (46/46) all pass. No `package.json` change.