### PR TITLE
ci: migrate setup-node and login-action to Node 24 (v6.4.0 / v4.2.0)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'yarn'
@@ -60,7 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
Bumps the two remaining GitHub Actions still on the **deprecated Node 20 runtime** (force-migrated by GitHub on **2026-06-16**) to their latest SHA-pinned Node 24 releases:

| Action | Was | Now |
|--------|-----|-----|
| `actions/setup-node` | v4 (Node 20) | **v6.4.0** (Node 24) |
| `docker/login-action` | v3 (Node 20) | **v4.2.0** (Node 24) |

## Risk
Drop-in. Inputs are unchanged across these majors — `node-version`/`cache` for setup-node, `username`/`password` for login-action. The major bump is the Node runtime only.

## Validation
- `setup-node` runs in the **verify** job → exercised directly by this PR's CI.
- `login-action` runs in the **build** job (push-only) → validated by the post-merge build on main.

Clears the Node 20 deprecation annotations seen in recent build runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies for improved build infrastructure stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/tgmr/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->